### PR TITLE
fix: Extract actual answer text in evals runner

### DIFF
--- a/src/d4bl/evals/runner.py
+++ b/src/d4bl/evals/runner.py
@@ -42,13 +42,16 @@ async def run_evals_and_log(
         async with sem:
             raw_result = job.result
             if isinstance(raw_result, dict):
-                research_output = (
+                candidate = (
                     raw_result.get("raw_output")
                     or raw_result.get("answer")
+                    or raw_result.get("text")
+                    or raw_result.get("output")
                     or ""
                 )
+                research_output = str(candidate).strip()
             else:
-                research_output = str(raw_result or "")
+                research_output = str(raw_result or "").strip()
             if not research_output:
                 logger.warning("Job %s has no result, skipping.", job.job_id)
                 return


### PR DESCRIPTION
## Summary

- Extract `raw_output` from the result JSON dict instead of stringifying the entire result object, so evaluators receive human-readable text
- Use `job.trace_id` when available (set by Langfuse instrumentation) before falling back to `job.job_id`, preserving trace correlation

Closes #16

## Test plan

- [x] `pytest tests/ -v` — all 52 tests pass
- [ ] Manual: run evaluations against a completed job and verify evaluator receives readable text, not a JSON blob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result extraction to handle varied result formats more reliably, reducing missing or incorrect evaluation outputs.
  * Strengthened trace identification passed through evaluation flows to improve observability and debugging of evaluation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->