### PR TITLE
Fix Jekyll build: wrap JSX code blocks in raw tags

### DIFF
--- a/docs/plans/2026-02-19-explore-data-page.md
+++ b/docs/plans/2026-02-19-explore-data-page.md
@@ -1441,6 +1441,7 @@ export default function MetricFilterPanel({ filters, onChange }: Props) {
 
 **Step 2: Create the choropleth map component**
 
+{% raw %}
 ```tsx
 // ui-nextjs/components/explore/StateMap.tsx
 'use client';
@@ -1527,6 +1528,7 @@ export default function StateMap({ indicators, selectedStateFips, onSelectState 
   );
 }
 ```
+{% endraw %}
 
 **Step 3: Run build to check TypeScript**
 
@@ -1556,6 +1558,7 @@ git commit -m "feat: Add MetricFilterPanel and StateMap explore components"
 
 **Step 1: Create RacialGapChart**
 
+{% raw %}
 ```tsx
 // ui-nextjs/components/explore/RacialGapChart.tsx
 'use client';
@@ -1645,6 +1648,7 @@ export default function RacialGapChart({ indicators, metric, stateName }: Props)
   );
 }
 ```
+{% endraw %}
 
 **Step 2: Create PolicyTable**
 


### PR DESCRIPTION
## Summary

- Wraps two TSX code blocks in `{% raw %}...{% endraw %}` tags in `docs/plans/2026-02-19-explore-data-page.md`
- Jekyll was interpreting `{{ }}` in JSX code as Liquid template variables, causing `pages build and deployment` to fail since March 3rd

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning documentation with design specifications and component concepts for upcoming data exploration interface features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->