### PR TITLE
Explore: add description banner, metric tooltips, and skeleton loading

### DIFF
--- a/ui-nextjs/app/explore/page.tsx
+++ b/ui-nextjs/app/explore/page.tsx
@@ -269,8 +269,16 @@ export default function ExplorePage() {
                   nationalAverage={exploreData.national_average}
                 />
                 {loading && (
-                  <div className="absolute inset-0 bg-[#292929]/60 rounded-lg flex items-center justify-center">
-                    <div className="w-6 h-6 border-2 border-gray-500 border-t-white rounded-full animate-spin" />
+                  <div
+                    className="absolute inset-0 bg-[#292929]/60 rounded-lg flex items-center justify-center"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    <div
+                      className="w-6 h-6 border-2 border-gray-500 border-t-white rounded-full animate-spin"
+                      aria-hidden="true"
+                    />
+                    <span className="sr-only">Updating map data</span>
                   </div>
                 )}
               </div>

--- a/ui-nextjs/components/explore/MetricFilterPanel.tsx
+++ b/ui-nextjs/components/explore/MetricFilterPanel.tsx
@@ -119,8 +119,17 @@ export default function MetricFilterPanel({
                 <span className="text-sm text-gray-300">{m.label}</span>
                 {sourceKey && METRIC_DESCRIPTIONS[sourceKey]?.[m.value] && (
                   <span className="relative group ml-1">
-                    <span className="text-gray-500 cursor-help text-xs">i</span>
-                    <span className="invisible group-hover:visible absolute left-4 bottom-full mb-1 w-52 px-2 py-1 text-xs text-gray-200 bg-[#404040] rounded shadow-lg z-10">
+                    <button
+                      type="button"
+                      aria-label={`More info about ${m.label}`}
+                      className="text-gray-500 cursor-help text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-gray-300 rounded-sm"
+                    >
+                      <span aria-hidden="true">i</span>
+                    </button>
+                    <span
+                      role="tooltip"
+                      className="invisible group-hover:visible group-focus-within:visible absolute left-4 bottom-full mb-1 w-52 px-2 py-1 text-xs text-gray-200 bg-[#404040] rounded shadow-lg z-10"
+                    >
                       {METRIC_DESCRIPTIONS[sourceKey][m.value]}
                     </span>
                   </span>


### PR DESCRIPTION
## Summary
- Adds source description banner below data source tabs with accent dot and "Learn more" link
- Adds metric tooltips (hover info icons) in the filter panel using `METRIC_DESCRIPTIONS`
- Replaces "Loading map data..." text with shimmer skeleton placeholders
- Adds loading overlay (spinner) on existing content during filter changes
- Adds skeleton state for MetricFilterPanel during initial load

## Test plan
- [ ] Verify description banner shows correct text when switching sources
- [ ] Verify tooltip appears on hover for metrics with descriptions
- [ ] Verify skeleton loading appears on initial page load and tab switch
- [ ] Verify spinner overlay appears during filter changes (not full skeleton replacement)
- [ ] `npm run build` passes

Closes #107, closes #108, closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source description banner below Data Source Tabs displaying source metadata.
  * Added informational tooltips for metrics when applicable.

* **Improvements**
  * Enhanced loading state with skeleton placeholders instead of static text.
  * Added semi-transparent loading overlay with spinner on map during data fetch.
  * Improved visual feedback when switching between data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->