### PR TITLE
feat: flywheel metrics dashboard in admin UI (#155)

### DIFF
--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -27,7 +27,6 @@ from starlette.requests import Request
 from d4bl.app.auth import CurrentUser, get_current_user, require_admin
 from d4bl.app.cache import explore_cache
 from d4bl.app.data_routes import router as data_router
-from d4bl.app.flywheel_routes import router as flywheel_router
 from d4bl.app.explore_helpers import (
     FIPS_TO_STATE_NAME,
     build_response_from_summary,
@@ -36,6 +35,7 @@ from d4bl.app.explore_helpers import (
     distinct_values,
 )
 from d4bl.app.explore_insights import router as explore_insights_router
+from d4bl.app.flywheel_routes import router as flywheel_router
 from d4bl.app.schedule_routes import router as schedule_router
 from d4bl.app.schemas import (
     CompareRequest,

--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -27,6 +27,7 @@ from starlette.requests import Request
 from d4bl.app.auth import CurrentUser, get_current_user, require_admin
 from d4bl.app.cache import explore_cache
 from d4bl.app.data_routes import router as data_router
+from d4bl.app.flywheel_routes import router as flywheel_router
 from d4bl.app.explore_helpers import (
     FIPS_TO_STATE_NAME,
     build_response_from_summary,
@@ -560,6 +561,7 @@ app.add_middleware(
 app.include_router(data_router)
 app.include_router(explore_insights_router)
 app.include_router(schedule_router)
+app.include_router(flywheel_router)
 
 # ---------------------------------------------------------------------------
 # Admin ingestion: track background subprocess jobs

--- a/src/d4bl/app/flywheel_routes.py
+++ b/src/d4bl/app/flywheel_routes.py
@@ -142,7 +142,8 @@ def _build_time_series(
 
         f1 = metrics.get("entity_f1")
         halluc = metrics.get("hallucination_accuracy")
-        scores = [s for s in [f1, halluc] if s is not None]
+        community_f1 = metrics.get("community_framing_f1")
+        scores = [s for s in [f1, halluc, community_f1] if s is not None]
         if scores:
             composite = round(sum(scores) / len(scores), 4)
             model_accuracy.append(TimeSeriesPoint(date=date_str, value=composite))

--- a/src/d4bl/app/flywheel_routes.py
+++ b/src/d4bl/app/flywheel_routes.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from d4bl.app.auth import require_admin
+from d4bl.app.auth import CurrentUser, require_admin
 from d4bl.app.schemas import (
     CorpusStats,
     FlywheelMetricsResponse,
@@ -164,7 +164,7 @@ def _build_time_series(
 
 @router.get("/api/admin/flywheel-metrics", response_model=FlywheelMetricsResponse)
 async def get_flywheel_metrics(
-    _user=Depends(require_admin),
+    _user: CurrentUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> FlywheelMetricsResponse:
     """Return aggregated flywheel metrics for the admin dashboard."""

--- a/src/d4bl/app/flywheel_routes.py
+++ b/src/d4bl/app/flywheel_routes.py
@@ -1,0 +1,193 @@
+"""Flywheel metrics admin endpoint.
+
+Aggregates corpus diversity, model accuracy, and research quality
+metrics for the D4BL data flywheel dashboard.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from d4bl.app.auth import require_admin
+from d4bl.app.schemas import (
+    CorpusStats,
+    FlywheelMetricsResponse,
+    ResearchQualityItem,
+    TimeSeriesPoint,
+    TrainingRunItem,
+)
+from d4bl.infra.database import get_db
+
+router = APIRouter()
+
+
+async def _query_corpus(db: AsyncSession) -> CorpusStats:
+    """Query corpus composition from documents + document_chunks."""
+    result = await db.execute(
+        text("""
+            SELECT d.content_type,
+                   COUNT(dc.id) AS chunk_count,
+                   COALESCE(SUM(dc.token_count), 0) AS total_tokens
+            FROM document_chunks dc
+            JOIN documents d ON dc.document_id = d.id
+            GROUP BY d.content_type
+            ORDER BY chunk_count DESC
+        """)
+    )
+    rows = result.mappings().all()
+
+    content_types: dict[str, int] = {}
+    total_chunks = 0
+    total_tokens = 0
+    for row in rows:
+        ct = row["content_type"]
+        count = int(row["chunk_count"])
+        tokens = int(row["total_tokens"])
+        content_types[ct] = count
+        total_chunks += count
+        total_tokens += tokens
+
+    return CorpusStats(
+        total_chunks=total_chunks,
+        total_tokens=total_tokens,
+        content_types=content_types,
+        unstructured_pct=0.0,
+    )
+
+
+async def _query_training_runs(db: AsyncSession) -> list[dict]:
+    """Query model evaluation runs ordered by date."""
+    result = await db.execute(
+        text("""
+            SELECT model_version, task, metrics, ship_decision, created_at
+            FROM model_eval_runs
+            ORDER BY created_at DESC
+            LIMIT 20
+        """)
+    )
+    return [dict(row) for row in result.mappings().all()]
+
+
+async def _query_research_quality(db: AsyncSession) -> dict[str, ResearchQualityItem]:
+    """Query average evaluation scores grouped by eval type."""
+    result = await db.execute(
+        text("""
+            SELECT eval_name,
+                   AVG(score) AS avg_score,
+                   COUNT(*) AS eval_count
+            FROM evaluation_results
+            WHERE score IS NOT NULL
+            GROUP BY eval_name
+            ORDER BY eval_name
+        """)
+    )
+    rows = result.mappings().all()
+    return {
+        row["eval_name"]: ResearchQualityItem(
+            avg_score=round(float(row["avg_score"]), 4),
+            count=int(row["eval_count"]),
+        )
+        for row in rows
+    }
+
+
+async def _query_research_quality_timeseries(db: AsyncSession) -> list[dict]:
+    """Query monthly average evaluation scores for the time-series chart."""
+    result = await db.execute(
+        text("""
+            SELECT DATE_TRUNC('month', created_at) AS month,
+                   AVG(score) AS avg_score
+            FROM evaluation_results
+            WHERE score IS NOT NULL
+            GROUP BY DATE_TRUNC('month', created_at)
+            ORDER BY month
+        """)
+    )
+    return [dict(row) for row in result.mappings().all()]
+
+
+def _build_time_series(
+    training_rows: list[dict],
+    rq_timeseries_rows: list[dict],
+) -> tuple[list[TimeSeriesPoint], list[TimeSeriesPoint], list[TimeSeriesPoint]]:
+    """Derive time-series data from training runs and evaluation results."""
+    corpus_diversity: list[TimeSeriesPoint] = []
+    model_accuracy: list[TimeSeriesPoint] = []
+
+    for run in training_rows:
+        metrics = run.get("metrics") or {}
+        created = run.get("created_at")
+        if not created:
+            continue
+        date_str = created.strftime("%Y-%m-%d") if hasattr(created, "strftime") else str(created)[:10]
+
+        corpus_stats = metrics.get("corpus_stats", {})
+        structured = corpus_stats.get("structured_passages", 0)
+        unstructured = corpus_stats.get("unstructured_passages", 0)
+        total = structured + unstructured
+        if total > 0:
+            pct = round(unstructured / total * 100, 1)
+            corpus_diversity.append(TimeSeriesPoint(date=date_str, value=pct))
+
+        f1 = metrics.get("entity_f1")
+        halluc = metrics.get("hallucination_accuracy")
+        scores = [s for s in [f1, halluc] if s is not None]
+        if scores:
+            composite = round(sum(scores) / len(scores), 4)
+            model_accuracy.append(TimeSeriesPoint(date=date_str, value=composite))
+
+    rq_points: list[TimeSeriesPoint] = []
+    for row in rq_timeseries_rows:
+        date_str = str(row["month"])[:10]
+        rq_points.append(
+            TimeSeriesPoint(date=date_str, value=round(float(row["avg_score"]), 4))
+        )
+
+    # Reverse so oldest is first (training_rows are DESC)
+    corpus_diversity.reverse()
+    model_accuracy.reverse()
+
+    return corpus_diversity, model_accuracy, rq_points
+
+
+@router.get("/api/admin/flywheel-metrics", response_model=FlywheelMetricsResponse)
+async def get_flywheel_metrics(
+    _user=Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> FlywheelMetricsResponse:
+    """Return aggregated flywheel metrics for the admin dashboard."""
+    corpus = await _query_corpus(db)
+    training_rows = await _query_training_runs(db)
+    research_quality = await _query_research_quality(db)
+    rq_timeseries_rows = await _query_research_quality_timeseries(db)
+
+    training_items = [
+        TrainingRunItem(
+            model_version=r["model_version"],
+            task=r["task"],
+            metrics=r["metrics"] or {},
+            ship_decision=r["ship_decision"],
+            created_at=r["created_at"].isoformat() if r.get("created_at") else None,
+        )
+        for r in training_rows
+    ]
+
+    corpus_diversity, model_accuracy, rq_points = _build_time_series(
+        training_rows, rq_timeseries_rows
+    )
+
+    if corpus_diversity:
+        corpus.unstructured_pct = corpus_diversity[-1].value
+
+    return FlywheelMetricsResponse(
+        corpus=corpus,
+        training_runs=training_items,
+        research_quality=research_quality,
+        time_series={
+            "corpus_diversity": corpus_diversity,
+            "model_accuracy": model_accuracy,
+            "research_quality": rq_points,
+        },
+    )

--- a/src/d4bl/app/flywheel_routes.py
+++ b/src/d4bl/app/flywheel_routes.py
@@ -23,8 +23,7 @@ from d4bl.infra.database import get_db
 router = APIRouter()
 
 
-async def _query_corpus(db: AsyncSession) -> CorpusStats:
-    """Query corpus composition from documents + document_chunks."""
+async def _query_corpus(db: AsyncSession) -> tuple[dict[str, int], int, int]:
     result = await db.execute(
         text("""
             SELECT d.content_type,
@@ -42,23 +41,14 @@ async def _query_corpus(db: AsyncSession) -> CorpusStats:
     total_chunks = 0
     total_tokens = 0
     for row in rows:
-        ct = row["content_type"]
-        count = int(row["chunk_count"])
-        tokens = int(row["total_tokens"])
-        content_types[ct] = count
-        total_chunks += count
-        total_tokens += tokens
+        content_types[row["content_type"]] = int(row["chunk_count"])
+        total_chunks += int(row["chunk_count"])
+        total_tokens += int(row["total_tokens"])
 
-    return CorpusStats(
-        total_chunks=total_chunks,
-        total_tokens=total_tokens,
-        content_types=content_types,
-        unstructured_pct=0.0,
-    )
+    return content_types, total_chunks, total_tokens
 
 
 async def _query_training_runs(db: AsyncSession) -> list[dict]:
-    """Query model evaluation runs ordered by date."""
     result = await db.execute(
         text("""
             SELECT model_version, task, metrics, ship_decision, created_at
@@ -70,42 +60,61 @@ async def _query_training_runs(db: AsyncSession) -> list[dict]:
     return [dict(row) for row in result.mappings().all()]
 
 
-async def _query_research_quality(db: AsyncSession) -> dict[str, ResearchQualityItem]:
-    """Query average evaluation scores grouped by eval type."""
+async def _query_evaluation_results(
+    db: AsyncSession,
+) -> tuple[dict[str, ResearchQualityItem], list[dict]]:
+    """Single scan of evaluation_results returning both per-eval-name aggregates and monthly time-series."""
     result = await db.execute(
         text("""
             SELECT eval_name,
+                   DATE_TRUNC('month', created_at) AS month,
                    AVG(score) AS avg_score,
                    COUNT(*) AS eval_count
             FROM evaluation_results
             WHERE score IS NOT NULL
-            GROUP BY eval_name
-            ORDER BY eval_name
+              AND created_at >= NOW() - INTERVAL '24 months'
+            GROUP BY eval_name, DATE_TRUNC('month', created_at)
+            ORDER BY eval_name, month
         """)
     )
     rows = result.mappings().all()
-    return {
-        row["eval_name"]: ResearchQualityItem(
-            avg_score=round(float(row["avg_score"]), 4),
-            count=int(row["eval_count"]),
+
+    # Aggregate per eval_name (sum across months)
+    by_name: dict[str, dict] = {}
+    monthly: dict[str, list[float]] = {}
+    for row in rows:
+        name = row["eval_name"]
+        avg = float(row["avg_score"])
+        count = int(row["eval_count"])
+        if name not in by_name:
+            by_name[name] = {"total_score": 0.0, "total_count": 0}
+        by_name[name]["total_score"] += avg * count
+        by_name[name]["total_count"] += count
+
+        month_key = str(row["month"])[:10]
+        monthly.setdefault(month_key, []).append(avg * count)
+        monthly.setdefault(f"{month_key}_count", []).append(count)
+
+    research_quality = {
+        name: ResearchQualityItem(
+            avg_score=round(data["total_score"] / data["total_count"], 4),
+            count=data["total_count"],
         )
-        for row in rows
+        for name, data in by_name.items()
     }
 
+    # Build monthly averages across all eval types
+    month_keys = sorted(k for k in monthly if not k.endswith("_count"))
+    timeseries_rows = []
+    for mk in month_keys:
+        total_score = sum(monthly[mk])
+        total_count = sum(monthly[f"{mk}_count"])
+        timeseries_rows.append({
+            "month": mk,
+            "avg_score": total_score / total_count if total_count else 0,
+        })
 
-async def _query_research_quality_timeseries(db: AsyncSession) -> list[dict]:
-    """Query monthly average evaluation scores for the time-series chart."""
-    result = await db.execute(
-        text("""
-            SELECT DATE_TRUNC('month', created_at) AS month,
-                   AVG(score) AS avg_score
-            FROM evaluation_results
-            WHERE score IS NOT NULL
-            GROUP BY DATE_TRUNC('month', created_at)
-            ORDER BY month
-        """)
-    )
-    return [dict(row) for row in result.mappings().all()]
+    return research_quality, timeseries_rows
 
 
 def _build_time_series(
@@ -158,10 +167,9 @@ async def get_flywheel_metrics(
     db: AsyncSession = Depends(get_db),
 ) -> FlywheelMetricsResponse:
     """Return aggregated flywheel metrics for the admin dashboard."""
-    corpus = await _query_corpus(db)
+    content_types, total_chunks, total_tokens = await _query_corpus(db)
     training_rows = await _query_training_runs(db)
-    research_quality = await _query_research_quality(db)
-    rq_timeseries_rows = await _query_research_quality_timeseries(db)
+    research_quality, rq_timeseries_rows = await _query_evaluation_results(db)
 
     training_items = [
         TrainingRunItem(
@@ -178,11 +186,15 @@ async def get_flywheel_metrics(
         training_rows, rq_timeseries_rows
     )
 
-    if corpus_diversity:
-        corpus.unstructured_pct = corpus_diversity[-1].value
+    unstructured_pct = corpus_diversity[-1].value if corpus_diversity else 0.0
 
     return FlywheelMetricsResponse(
-        corpus=corpus,
+        corpus=CorpusStats(
+            total_chunks=total_chunks,
+            total_tokens=total_tokens,
+            content_types=content_types,
+            unstructured_pct=unstructured_pct,
+        ),
         training_runs=training_items,
         research_quality=research_quality,
         time_series={

--- a/src/d4bl/app/schemas.py
+++ b/src/d4bl/app/schemas.py
@@ -582,3 +582,48 @@ class AnalyzeResponse(BaseModel):
 
     run_id: str
     suggestions: dict
+
+
+# --- Flywheel Metrics models ---
+
+
+class CorpusStats(BaseModel):
+    """Corpus composition statistics."""
+
+    total_chunks: int
+    total_tokens: int
+    content_types: dict[str, int]
+    unstructured_pct: float
+
+
+class TrainingRunItem(BaseModel):
+    """A training run with key metrics for the flywheel dashboard."""
+
+    model_version: str
+    task: str
+    metrics: dict[str, Any]
+    ship_decision: str
+    created_at: str | None = None
+
+
+class ResearchQualityItem(BaseModel):
+    """Average evaluation score for a single eval type."""
+
+    avg_score: float
+    count: int
+
+
+class TimeSeriesPoint(BaseModel):
+    """A single data point on a time-series chart."""
+
+    date: str
+    value: float
+
+
+class FlywheelMetricsResponse(BaseModel):
+    """Full flywheel metrics dashboard response."""
+
+    corpus: CorpusStats
+    training_runs: list[TrainingRunItem]
+    research_quality: dict[str, ResearchQualityItem]
+    time_series: dict[str, list[TimeSeriesPoint]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def _patch_settings():
     """Patch settings for auth testing."""
     mock_settings = MagicMock()
     mock_settings.supabase_jwt_secret = _PATCH_SETTINGS_SECRET
+    mock_settings.supabase_url = None
     mock_settings.cors_allowed_origins = ("*",)
     with patch("d4bl.app.auth.get_settings", return_value=mock_settings):
         with patch("d4bl.app.api.get_settings", return_value=mock_settings):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,26 @@
 """Shared test fixtures for D4BL tests."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from d4bl.app.auth import CurrentUser, get_current_user
+
+_PATCH_SETTINGS_SECRET = "test-jwt-secret"
+
+
+@pytest.fixture
+def _patch_settings():
+    """Patch settings for auth testing."""
+    mock_settings = MagicMock()
+    mock_settings.supabase_jwt_secret = _PATCH_SETTINGS_SECRET
+    mock_settings.cors_allowed_origins = ("*",)
+    with patch("d4bl.app.auth.get_settings", return_value=mock_settings):
+        with patch("d4bl.app.api.get_settings", return_value=mock_settings):
+            with patch("d4bl.settings.get_settings", return_value=mock_settings):
+                yield
 
 TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
 TEST_ADMIN_ID = "00000000-0000-0000-0000-000000000002"

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -24,17 +24,6 @@ def _make_token(sub: str, email: str = "test@example.com") -> str:
     return jwt.encode(payload, TEST_SECRET, algorithm="HS256")
 
 
-@pytest.fixture
-def _patch_settings():
-    """Patch settings for auth testing."""
-    mock_settings = MagicMock()
-    mock_settings.supabase_jwt_secret = TEST_SECRET
-    mock_settings.cors_allowed_origins = ("*",)
-    with patch("d4bl.app.auth.get_settings", return_value=mock_settings):
-        with patch("d4bl.app.api.get_settings", return_value=mock_settings):
-            with patch("d4bl.settings.get_settings", return_value=mock_settings):
-                yield
-
 
 def test_research_endpoint_requires_auth(_patch_settings):
     """POST /api/research without a token returns 401."""

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import jwt
-import pytest
 from fastapi.testclient import TestClient
 
 TEST_SECRET = "test-jwt-secret"

--- a/tests/test_flywheel_metrics.py
+++ b/tests/test_flywheel_metrics.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_flywheel_metrics.py
+++ b/tests/test_flywheel_metrics.py
@@ -1,0 +1,144 @@
+"""Tests for GET /api/admin/flywheel-metrics endpoint."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestFlywheelMetricsAuth:
+    """Flywheel metrics endpoint requires admin auth."""
+
+    def test_requires_auth(self, _patch_settings):
+        from d4bl.app.api import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/api/admin/flywheel-metrics")
+        assert response.status_code == 401
+
+
+class TestFlywheelMetricsEmpty:
+    """Flywheel metrics with no data returns zero-value defaults."""
+
+    def test_empty_database(self, override_admin_auth):
+        from d4bl.infra.database import get_db
+
+        app = override_admin_auth
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.mappings.return_value.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        async def mock_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = mock_get_db
+
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.get("/api/admin/flywheel-metrics")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert data["corpus"]["total_chunks"] == 0
+            assert data["corpus"]["total_tokens"] == 0
+            assert data["corpus"]["content_types"] == {}
+            assert data["corpus"]["unstructured_pct"] == 0.0
+            assert data["training_runs"] == []
+            assert data["research_quality"] == {}
+            assert data["time_series"]["corpus_diversity"] == []
+            assert data["time_series"]["model_accuracy"] == []
+            assert data["time_series"]["research_quality"] == []
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+class TestFlywheelMetricsWithData:
+    """Flywheel metrics with data returns computed values."""
+
+    def test_with_corpus_and_training_data(self, override_admin_auth):
+        from d4bl.infra.database import get_db
+
+        app = override_admin_auth
+
+        mock_db = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+
+            if call_count == 1:
+                # Corpus query
+                mock_result.mappings.return_value.all.return_value = [
+                    {"content_type": "policy_bill", "chunk_count": 200, "total_tokens": 500000},
+                    {"content_type": "research_report", "chunk_count": 100, "total_tokens": 250000},
+                ]
+            elif call_count == 2:
+                # Training runs query
+                mock_result.mappings.return_value.all.return_value = [
+                    {
+                        "model_version": "v3.0",
+                        "task": "parser",
+                        "metrics": {
+                            "entity_f1": 0.82,
+                            "hallucination_accuracy": 0.91,
+                            "corpus_stats": {
+                                "structured_passages": 1000,
+                                "unstructured_passages": 300,
+                            },
+                        },
+                        "ship_decision": "ship",
+                        "created_at": datetime(2026, 3, 15, tzinfo=timezone.utc),
+                    },
+                ]
+            elif call_count == 3:
+                # Research quality query
+                mock_result.mappings.return_value.all.return_value = [
+                    {"eval_name": "hallucination_accuracy", "avg_score": 0.88, "eval_count": 42},
+                    {"eval_name": "relevance", "avg_score": 0.76, "eval_count": 42},
+                ]
+            elif call_count == 4:
+                # Research quality timeseries query
+                mock_result.mappings.return_value.all.return_value = [
+                    {"month": datetime(2026, 3, 1, tzinfo=timezone.utc), "avg_score": 0.82},
+                ]
+            else:
+                mock_result.mappings.return_value.all.return_value = []
+
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        async def mock_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = mock_get_db
+
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.get("/api/admin/flywheel-metrics")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert data["corpus"]["total_chunks"] == 300
+            assert data["corpus"]["total_tokens"] == 750000
+            assert data["corpus"]["content_types"]["policy_bill"] == 200
+
+            assert len(data["training_runs"]) == 1
+            assert data["training_runs"][0]["model_version"] == "v3.0"
+
+            assert "hallucination_accuracy" in data["research_quality"]
+            assert data["research_quality"]["hallucination_accuracy"]["avg_score"] == 0.88
+
+            assert len(data["time_series"]["corpus_diversity"]) == 1
+            assert len(data["time_series"]["model_accuracy"]) == 1
+            assert len(data["time_series"]["research_quality"]) == 1
+        finally:
+            app.dependency_overrides.pop(get_db, None)

--- a/tests/test_flywheel_metrics.py
+++ b/tests/test_flywheel_metrics.py
@@ -99,15 +99,10 @@ class TestFlywheelMetricsWithData:
                     },
                 ]
             elif call_count == 3:
-                # Research quality query
+                # Combined evaluation_results query (per eval_name + month)
                 mock_result.mappings.return_value.all.return_value = [
-                    {"eval_name": "hallucination_accuracy", "avg_score": 0.88, "eval_count": 42},
-                    {"eval_name": "relevance", "avg_score": 0.76, "eval_count": 42},
-                ]
-            elif call_count == 4:
-                # Research quality timeseries query
-                mock_result.mappings.return_value.all.return_value = [
-                    {"month": datetime(2026, 3, 1, tzinfo=timezone.utc), "avg_score": 0.82},
+                    {"eval_name": "hallucination_accuracy", "month": datetime(2026, 3, 1, tzinfo=timezone.utc), "avg_score": 0.88, "eval_count": 42},
+                    {"eval_name": "relevance", "month": datetime(2026, 3, 1, tzinfo=timezone.utc), "avg_score": 0.76, "eval_count": 42},
                 ]
             else:
                 mock_result.mappings.return_value.all.return_value = []

--- a/ui-nextjs/app/admin/page.tsx
+++ b/ui-nextjs/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
 import { API_BASE, getCostSummary, CostSummary } from '@/lib/api';
 import DataStatusCard from '@/components/data/DataStatusCard';
+import FlywheelDashboard from '@/components/admin/FlywheelDashboard';
 
 interface UserProfile {
   id: string;
@@ -195,6 +196,9 @@ export default function AdminPage() {
     <div className="min-h-screen bg-[#292929]">
       <div className="max-w-4xl mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold text-white mb-8">User Management</h1>
+
+        {/* Flywheel Metrics Dashboard */}
+        <FlywheelDashboard accessToken={session?.access_token} />
 
         {/* External tools */}
         <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg p-6 mb-8">

--- a/ui-nextjs/components/admin/CorpusBreakdown.tsx
+++ b/ui-nextjs/components/admin/CorpusBreakdown.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+
+interface CorpusBreakdownProps {
+  contentTypes: Record<string, number>;
+}
+
+export default function CorpusBreakdown({ contentTypes }: CorpusBreakdownProps) {
+  const data = Object.entries(contentTypes)
+    .map(([name, count]) => ({ name: name.replace(/_/g, ' '), count }))
+    .sort((a, b) => b.count - a.count);
+
+  if (data.length === 0) {
+    return (
+      <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg px-4 py-12 text-center">
+        <p className="text-gray-500 text-sm">No documents ingested yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg p-4">
+      <h4 className="text-sm font-semibold text-white mb-4">Corpus Composition</h4>
+      <ResponsiveContainer width="100%" height={Math.max(160, data.length * 36)}>
+        <BarChart data={data} layout="vertical" margin={{ left: 20 }}>
+          <CartesianGrid stroke="#404040" strokeDasharray="3 3" horizontal={false} />
+          <XAxis
+            type="number"
+            tick={{ fill: '#9ca3af', fontSize: 10 }}
+            stroke="#404040"
+          />
+          <YAxis
+            type="category"
+            dataKey="name"
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            stroke="#404040"
+            width={110}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1a1a1a',
+              border: '1px solid #404040',
+              borderRadius: '6px',
+              color: '#d1d5db',
+              fontSize: 12,
+            }}
+            labelStyle={{ color: '#9ca3af' }}
+          />
+          <Bar dataKey="count" fill="#00ff32" radius={[0, 4, 4, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/ui-nextjs/components/admin/CorpusBreakdown.tsx
+++ b/ui-nextjs/components/admin/CorpusBreakdown.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   CartesianGrid,
 } from 'recharts';
+import { DARK_TOOLTIP_STYLE } from './flywheel-types';
 
 interface CorpusBreakdownProps {
   contentTypes: Record<string, number>;
@@ -45,16 +46,7 @@ export default function CorpusBreakdown({ contentTypes }: CorpusBreakdownProps) 
             stroke="#404040"
             width={110}
           />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: '#1a1a1a',
-              border: '1px solid #404040',
-              borderRadius: '6px',
-              color: '#d1d5db',
-              fontSize: 12,
-            }}
-            labelStyle={{ color: '#9ca3af' }}
-          />
+          <Tooltip {...DARK_TOOLTIP_STYLE} />
           <Bar dataKey="count" fill="#00ff32" radius={[0, 4, 4, 0]} />
         </BarChart>
       </ResponsiveContainer>

--- a/ui-nextjs/components/admin/FlywheelDashboard.tsx
+++ b/ui-nextjs/components/admin/FlywheelDashboard.tsx
@@ -18,7 +18,12 @@ export default function FlywheelDashboard({ accessToken }: FlywheelDashboardProp
   const [error, setError] = useState<string | null>(null);
 
   const fetchMetrics = useCallback(async () => {
-    if (!accessToken) return;
+    if (!accessToken) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -49,7 +54,7 @@ export default function FlywheelDashboard({ accessToken }: FlywheelDashboardProp
       <h2 className="text-lg font-semibold text-white mb-6">D4BL Data Flywheel</h2>
 
       {error && (
-        <div className="bg-red-900/30 border border-red-700 rounded px-4 py-3 mb-4">
+        <div className="bg-red-900/30 border border-red-700 rounded px-4 py-3 mb-4" role="alert" aria-live="assertive">
           <p className="text-red-400 text-sm">{error}</p>
         </div>
       )}

--- a/ui-nextjs/components/admin/FlywheelDashboard.tsx
+++ b/ui-nextjs/components/admin/FlywheelDashboard.tsx
@@ -2,41 +2,11 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { API_BASE } from '@/lib/api';
+import type { FlywheelData } from './flywheel-types';
 import FlywheelDiagram from './FlywheelDiagram';
 import FlywheelTimeSeries from './FlywheelTimeSeries';
 import CorpusBreakdown from './CorpusBreakdown';
 import ModelVersionTable from './ModelVersionTable';
-
-interface CorpusStats {
-  total_chunks: number;
-  total_tokens: number;
-  content_types: Record<string, number>;
-  unstructured_pct: number;
-}
-
-interface TrainingRun {
-  model_version: string;
-  task: string;
-  metrics: Record<string, unknown>;
-  ship_decision: string;
-  created_at: string | null;
-}
-
-interface TimeSeriesPoint {
-  date: string;
-  value: number;
-}
-
-interface FlywheelData {
-  corpus: CorpusStats;
-  training_runs: TrainingRun[];
-  research_quality: Record<string, { avg_score: number; count: number }>;
-  time_series: {
-    corpus_diversity: TimeSeriesPoint[];
-    model_accuracy: TimeSeriesPoint[];
-    research_quality: TimeSeriesPoint[];
-  };
-}
 
 interface FlywheelDashboardProps {
   accessToken: string | undefined;
@@ -49,6 +19,8 @@ export default function FlywheelDashboard({ accessToken }: FlywheelDashboardProp
 
   const fetchMetrics = useCallback(async () => {
     if (!accessToken) return;
+    setLoading(true);
+    setError(null);
     try {
       const response = await fetch(`${API_BASE}/api/admin/flywheel-metrics`, {
         headers: {
@@ -88,7 +60,6 @@ export default function FlywheelDashboard({ accessToken }: FlywheelDashboardProp
         </div>
       ) : (
         <>
-          {/* Top row: Diagram + Time Series */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
             <FlywheelDiagram />
             <FlywheelTimeSeries
@@ -100,7 +71,6 @@ export default function FlywheelDashboard({ accessToken }: FlywheelDashboardProp
             />
           </div>
 
-          {/* Bottom row: Corpus Breakdown + Model Versions */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CorpusBreakdown contentTypes={data?.corpus.content_types ?? {}} />
             <ModelVersionTable runs={data?.training_runs ?? []} />

--- a/ui-nextjs/components/admin/FlywheelDashboard.tsx
+++ b/ui-nextjs/components/admin/FlywheelDashboard.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { API_BASE } from '@/lib/api';
+import FlywheelDiagram from './FlywheelDiagram';
+import FlywheelTimeSeries from './FlywheelTimeSeries';
+import CorpusBreakdown from './CorpusBreakdown';
+import ModelVersionTable from './ModelVersionTable';
+
+interface CorpusStats {
+  total_chunks: number;
+  total_tokens: number;
+  content_types: Record<string, number>;
+  unstructured_pct: number;
+}
+
+interface TrainingRun {
+  model_version: string;
+  task: string;
+  metrics: Record<string, unknown>;
+  ship_decision: string;
+  created_at: string | null;
+}
+
+interface TimeSeriesPoint {
+  date: string;
+  value: number;
+}
+
+interface FlywheelData {
+  corpus: CorpusStats;
+  training_runs: TrainingRun[];
+  research_quality: Record<string, { avg_score: number; count: number }>;
+  time_series: {
+    corpus_diversity: TimeSeriesPoint[];
+    model_accuracy: TimeSeriesPoint[];
+    research_quality: TimeSeriesPoint[];
+  };
+}
+
+interface FlywheelDashboardProps {
+  accessToken: string | undefined;
+}
+
+export default function FlywheelDashboard({ accessToken }: FlywheelDashboardProps) {
+  const [data, setData] = useState<FlywheelData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMetrics = useCallback(async () => {
+    if (!accessToken) return;
+    try {
+      const response = await fetch(`${API_BASE}/api/admin/flywheel-metrics`, {
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+        },
+      });
+      if (response.ok) {
+        setData(await response.json());
+      } else {
+        const body = await response.json().catch(() => ({}));
+        setError(body.detail || 'Failed to load flywheel metrics');
+      }
+    } catch {
+      setError('Failed to load flywheel metrics');
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    fetchMetrics();
+  }, [fetchMetrics]);
+
+  return (
+    <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg p-6 mb-8">
+      <h2 className="text-lg font-semibold text-white mb-6">D4BL Data Flywheel</h2>
+
+      {error && (
+        <div className="bg-red-900/30 border border-red-700 rounded px-4 py-3 mb-4">
+          <p className="text-red-400 text-sm">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <p className="text-gray-400 text-sm">Loading flywheel metrics...</p>
+        </div>
+      ) : (
+        <>
+          {/* Top row: Diagram + Time Series */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+            <FlywheelDiagram />
+            <FlywheelTimeSeries
+              timeSeries={data?.time_series ?? {
+                corpus_diversity: [],
+                model_accuracy: [],
+                research_quality: [],
+              }}
+            />
+          </div>
+
+          {/* Bottom row: Corpus Breakdown + Model Versions */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <CorpusBreakdown contentTypes={data?.corpus.content_types ?? {}} />
+            <ModelVersionTable runs={data?.training_runs ?? []} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui-nextjs/components/admin/FlywheelDiagram.tsx
+++ b/ui-nextjs/components/admin/FlywheelDiagram.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+export default function FlywheelDiagram() {
+  return (
+    <div className="flex justify-center py-4">
+      <svg viewBox="0 0 700 700" className="w-full max-w-[500px] h-auto" role="img" aria-label="D4BL Data Flywheel mapping technical stages to research methodology">
+        <defs>
+          <marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#818cf8" />
+          </marker>
+          <marker id="arrow-outer" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#a855f7" />
+          </marker>
+        </defs>
+
+        {/* Inner ring arrows (technical flywheel) */}
+        <path d="M 420 130 Q 520 170 540 280" stroke="#818cf8" strokeWidth="2.5" fill="none" markerEnd="url(#arrow)" opacity="0.6"/>
+        <path d="M 540 400 Q 520 510 420 555" stroke="#818cf8" strokeWidth="2.5" fill="none" markerEnd="url(#arrow)" opacity="0.6"/>
+        <path d="M 280 555 Q 180 510 160 400" stroke="#818cf8" strokeWidth="2.5" fill="none" markerEnd="url(#arrow)" opacity="0.6"/>
+        <path d="M 160 280 Q 180 170 280 130" stroke="#818cf8" strokeWidth="2.5" fill="none" markerEnd="url(#arrow)" opacity="0.6"/>
+
+        {/* Outer ring arrows (D4BL methodology) */}
+        <path d="M 470 68 Q 620 120 645 240" stroke="#a855f7" strokeWidth="2" fill="none" markerEnd="url(#arrow-outer)" opacity="0.4" strokeDasharray="6 3"/>
+        <path d="M 645 440 Q 620 570 470 625" stroke="#a855f7" strokeWidth="2" fill="none" markerEnd="url(#arrow-outer)" opacity="0.4" strokeDasharray="6 3"/>
+        <path d="M 230 625 Q 80 570 55 440" stroke="#a855f7" strokeWidth="2" fill="none" markerEnd="url(#arrow-outer)" opacity="0.4" strokeDasharray="6 3"/>
+        <path d="M 55 240 Q 80 120 230 68" stroke="#a855f7" strokeWidth="2" fill="none" markerEnd="url(#arrow-outer)" opacity="0.4" strokeDasharray="6 3"/>
+
+        {/* Center */}
+        <circle cx="350" cy="345" r="55" fill="#1a1a1a" stroke="#7c3aed" strokeWidth="1.5"/>
+        <text x="350" y="330" textAnchor="middle" fontSize="11" fontWeight="700" fill="#a78bfa">DATA AS</text>
+        <text x="350" y="346" textAnchor="middle" fontSize="11" fontWeight="700" fill="#a78bfa">PROTEST</text>
+        <text x="350" y="362" textAnchor="middle" fontSize="11" fontWeight="700" fill="#a78bfa">ACCOUNTABILITY</text>
+        <text x="350" y="378" textAnchor="middle" fontSize="11" fontWeight="700" fill="#a78bfa">COLLECTIVE ACTION</text>
+
+        {/* Stage 1: TOP — Documents In / Data Collection + Analysis */}
+        <rect x="195" y="10" width="310" height="28" rx="14" fill="#2d1b69" stroke="#a855f7" strokeWidth="1.5"/>
+        <text x="350" y="29" textAnchor="middle" fontSize="11" fontWeight="600" fill="#c4b5fd">D4BL: Data Collection + Analysis</text>
+
+        <rect x="225" y="48" width="250" height="72" rx="12" fill="#052e16" stroke="#22c55e" strokeWidth="2"/>
+        <text x="350" y="72" textAnchor="middle" fontSize="14" fontWeight="700" fill="#4ade80">1. Documents In</text>
+        <text x="350" y="90" textAnchor="middle" fontSize="11" fill="#86efac">Policy bills, research reports,</text>
+        <text x="350" y="105" textAnchor="middle" fontSize="11" fill="#86efac">news articles, community data</text>
+
+        {/* Stage 2: RIGHT — Training / Problem Identification */}
+        <rect x="555" y="295" width="145" height="46" rx="14" fill="#2d1b69" stroke="#a855f7" strokeWidth="1.5"/>
+        <text x="627" y="314" textAnchor="middle" fontSize="11" fontWeight="600" fill="#c4b5fd">D4BL: Problem</text>
+        <text x="627" y="330" textAnchor="middle" fontSize="11" fontWeight="600" fill="#c4b5fd">Identification</text>
+
+        <rect x="460" y="350" width="195" height="72" rx="12" fill="#0c1a3d" stroke="#3b82f6" strokeWidth="2"/>
+        <text x="557" y="374" textAnchor="middle" fontSize="14" fontWeight="700" fill="#60a5fa">2. Training</text>
+        <text x="557" y="392" textAnchor="middle" fontSize="11" fill="#93c5fd">Model learns to parse</text>
+        <text x="557" y="407" textAnchor="middle" fontSize="11" fill="#93c5fd">community framings</text>
+
+        {/* Stage 3: BOTTOM — Research Quality / Policy Innovation */}
+        <rect x="220" y="610" width="260" height="28" rx="14" fill="#2d1b69" stroke="#a855f7" strokeWidth="1.5"/>
+        <text x="350" y="629" textAnchor="middle" fontSize="11" fontWeight="600" fill="#c4b5fd">D4BL: Policy Innovation</text>
+
+        <rect x="215" y="540" width="270" height="62" rx="12" fill="#2d1600" stroke="#f59e0b" strokeWidth="2"/>
+        <text x="350" y="564" textAnchor="middle" fontSize="14" fontWeight="700" fill="#fbbf24">3. Research Quality</text>
+        <text x="350" y="584" textAnchor="middle" fontSize="11" fill="#fcd34d">Outputs connect data → policy levers</text>
+
+        {/* Stage 4: LEFT — Feedback / Community Power Building */}
+        <rect x="0" y="295" width="145" height="46" rx="14" fill="#2d1b69" stroke="#a855f7" strokeWidth="1.5"/>
+        <text x="72" y="314" textAnchor="middle" fontSize="11" fontWeight="600" fill="#c4b5fd">D4BL: Community</text>
+        <text x="72" y="330" textAnchor="middle" fontSize="11" fontWeight="600" fill="#c4b5fd">Power Building</text>
+
+        <rect x="45" y="350" width="195" height="72" rx="12" fill="#2d0a1e" stroke="#ec4899" strokeWidth="2"/>
+        <text x="142" y="374" textAnchor="middle" fontSize="14" fontWeight="700" fill="#f472b6">4. Feedback</text>
+        <text x="142" y="392" textAnchor="middle" fontSize="11" fill="#f9a8d4">Community use generates</text>
+        <text x="142" y="407" textAnchor="middle" fontSize="11" fill="#f9a8d4">new documents + corrections</text>
+
+        {/* Legend */}
+        <rect x="0" y="660" width="700" height="40" rx="8" fill="#1a1a1a" stroke="#404040" strokeWidth="1"/>
+        <line x1="30" y1="680" x2="70" y2="680" stroke="#818cf8" strokeWidth="2.5"/>
+        <text x="80" y="684" fontSize="11" fill="#9ca3af">Technical flywheel</text>
+        <line x1="260" y1="680" x2="300" y2="680" stroke="#a855f7" strokeWidth="2" strokeDasharray="6 3"/>
+        <text x="310" y="684" fontSize="11" fill="#9ca3af">D4BL methodology cycle</text>
+      </svg>
+    </div>
+  );
+}

--- a/ui-nextjs/components/admin/FlywheelTimeSeries.tsx
+++ b/ui-nextjs/components/admin/FlywheelTimeSeries.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+
+interface TimeSeriesPoint {
+  date: string;
+  value: number;
+}
+
+interface MiniChartProps {
+  title: string;
+  data: TimeSeriesPoint[];
+  color: string;
+  unit?: string;
+  emptyMessage?: string;
+}
+
+function MiniChart({ title, data, color, unit = '', emptyMessage }: MiniChartProps) {
+  const currentValue = data.length > 0 ? data[data.length - 1].value : null;
+
+  return (
+    <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg p-4">
+      <div className="flex items-baseline justify-between mb-3">
+        <h4 className="text-sm font-semibold text-white">{title}</h4>
+        {currentValue !== null && (
+          <span className="text-lg font-bold" style={{ color }}>
+            {currentValue}{unit}
+          </span>
+        )}
+      </div>
+      {data.length === 0 ? (
+        <div className="flex items-center justify-center h-[160px]">
+          <p className="text-gray-500 text-sm">{emptyMessage || 'No data yet'}</p>
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={160}>
+          <LineChart data={data}>
+            <CartesianGrid stroke="#404040" strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              tick={{ fill: '#9ca3af', fontSize: 10 }}
+              stroke="#404040"
+            />
+            <YAxis
+              tick={{ fill: '#9ca3af', fontSize: 10 }}
+              stroke="#404040"
+              width={40}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#1a1a1a',
+                border: '1px solid #404040',
+                borderRadius: '6px',
+                color: '#d1d5db',
+                fontSize: 12,
+              }}
+              labelStyle={{ color: '#9ca3af' }}
+            />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke={color}
+              strokeWidth={2}
+              dot={{ fill: color, r: 3 }}
+              activeDot={{ r: 5 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}
+
+interface FlywheelTimeSeriesProps {
+  timeSeries: {
+    corpus_diversity: TimeSeriesPoint[];
+    model_accuracy: TimeSeriesPoint[];
+    research_quality: TimeSeriesPoint[];
+  };
+}
+
+export default function FlywheelTimeSeries({ timeSeries }: FlywheelTimeSeriesProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4">
+      <MiniChart
+        title="Corpus Diversity"
+        data={timeSeries.corpus_diversity}
+        color="#22c55e"
+        unit="%"
+        emptyMessage="Metrics appear after training runs are recorded"
+      />
+      <MiniChart
+        title="Model Accuracy"
+        data={timeSeries.model_accuracy}
+        color="#3b82f6"
+        emptyMessage="Metrics appear after training runs are recorded"
+      />
+      <MiniChart
+        title="Research Output Quality"
+        data={timeSeries.research_quality}
+        color="#f59e0b"
+        emptyMessage="Metrics appear after evaluation runs complete"
+      />
+    </div>
+  );
+}

--- a/ui-nextjs/components/admin/FlywheelTimeSeries.tsx
+++ b/ui-nextjs/components/admin/FlywheelTimeSeries.tsx
@@ -9,11 +9,8 @@ import {
   Tooltip,
   CartesianGrid,
 } from 'recharts';
-
-interface TimeSeriesPoint {
-  date: string;
-  value: number;
-}
+import type { TimeSeriesPoint } from './flywheel-types';
+import { DARK_TOOLTIP_STYLE } from './flywheel-types';
 
 interface MiniChartProps {
   title: string;
@@ -54,16 +51,7 @@ function MiniChart({ title, data, color, unit = '', emptyMessage }: MiniChartPro
               stroke="#404040"
               width={40}
             />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: '#1a1a1a',
-                border: '1px solid #404040',
-                borderRadius: '6px',
-                color: '#d1d5db',
-                fontSize: 12,
-              }}
-              labelStyle={{ color: '#9ca3af' }}
-            />
+            <Tooltip {...DARK_TOOLTIP_STYLE} />
             <Line
               type="monotone"
               dataKey="value"

--- a/ui-nextjs/components/admin/ModelVersionTable.tsx
+++ b/ui-nextjs/components/admin/ModelVersionTable.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+interface TrainingRun {
+  model_version: string;
+  task: string;
+  metrics: Record<string, unknown>;
+  ship_decision: string;
+  created_at: string | null;
+}
+
+interface ModelVersionTableProps {
+  runs: TrainingRun[];
+}
+
+export default function ModelVersionTable({ runs }: ModelVersionTableProps) {
+  if (runs.length === 0) {
+    return (
+      <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg px-4 py-12 text-center">
+        <p className="text-gray-500 text-sm">No model evaluations recorded yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg overflow-hidden">
+      <h4 className="text-sm font-semibold text-white px-4 pt-4 pb-2">Model Versions</h4>
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-[#404040]">
+            <th className="px-4 py-2 text-left text-xs text-gray-400">Version</th>
+            <th className="px-4 py-2 text-left text-xs text-gray-400">Task</th>
+            <th className="px-4 py-2 text-left text-xs text-gray-400">Entity F1</th>
+            <th className="px-4 py-2 text-left text-xs text-gray-400">Halluc. Acc</th>
+            <th className="px-4 py-2 text-left text-xs text-gray-400">Decision</th>
+            <th className="px-4 py-2 text-left text-xs text-gray-400">Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run, i) => {
+            const f1 = typeof run.metrics.entity_f1 === 'number'
+              ? run.metrics.entity_f1.toFixed(3) : '—';
+            const halluc = typeof run.metrics.hallucination_accuracy === 'number'
+              ? run.metrics.hallucination_accuracy.toFixed(3) : '—';
+            const decisionColor = run.ship_decision === 'ship'
+              ? 'text-green-400' : run.ship_decision === 'no-ship'
+              ? 'text-red-400' : 'text-yellow-400';
+
+            return (
+              <tr key={`${run.model_version}-${run.task}-${i}`} className="border-b border-[#404040] last:border-0">
+                <td className="px-4 py-2 text-white text-sm font-mono">{run.model_version}</td>
+                <td className="px-4 py-2 text-gray-300 text-sm">{run.task}</td>
+                <td className="px-4 py-2 text-gray-300 text-sm font-mono">{f1}</td>
+                <td className="px-4 py-2 text-gray-300 text-sm font-mono">{halluc}</td>
+                <td className={`px-4 py-2 text-sm font-semibold ${decisionColor}`}>{run.ship_decision}</td>
+                <td className="px-4 py-2 text-gray-400 text-sm">
+                  {run.created_at ? new Date(run.created_at).toLocaleDateString() : '—'}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui-nextjs/components/admin/ModelVersionTable.tsx
+++ b/ui-nextjs/components/admin/ModelVersionTable.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-interface TrainingRun {
-  model_version: string;
-  task: string;
-  metrics: Record<string, unknown>;
-  ship_decision: string;
-  created_at: string | null;
-}
+import type { TrainingRun } from './flywheel-types';
 
 interface ModelVersionTableProps {
   runs: TrainingRun[];

--- a/ui-nextjs/components/admin/flywheel-types.ts
+++ b/ui-nextjs/components/admin/flywheel-types.ts
@@ -1,0 +1,41 @@
+export interface TimeSeriesPoint {
+  date: string;
+  value: number;
+}
+
+export interface TrainingRun {
+  model_version: string;
+  task: string;
+  metrics: Record<string, unknown>;
+  ship_decision: string;
+  created_at: string | null;
+}
+
+export interface CorpusStats {
+  total_chunks: number;
+  total_tokens: number;
+  content_types: Record<string, number>;
+  unstructured_pct: number;
+}
+
+export interface FlywheelData {
+  corpus: CorpusStats;
+  training_runs: TrainingRun[];
+  research_quality: Record<string, { avg_score: number; count: number }>;
+  time_series: {
+    corpus_diversity: TimeSeriesPoint[];
+    model_accuracy: TimeSeriesPoint[];
+    research_quality: TimeSeriesPoint[];
+  };
+}
+
+export const DARK_TOOLTIP_STYLE = {
+  contentStyle: {
+    backgroundColor: '#1a1a1a',
+    border: '1px solid #404040',
+    borderRadius: '6px',
+    color: '#d1d5db',
+    fontSize: 12,
+  },
+  labelStyle: { color: '#9ca3af' },
+} as const;


### PR DESCRIPTION
## Summary
- Add `GET /api/admin/flywheel-metrics` endpoint aggregating corpus diversity, model accuracy, and research quality from 3 database tables
- Build flywheel dashboard card with D4BL methodology SVG diagram, 3 time-series charts (recharts), corpus composition breakdown, and model version comparison table
- Place dashboard at top of admin page as executive summary for leadership

## Details
- Single optimized query for evaluation_results (merged two queries into one scan with 24-month lookback)
- Dark theme consistent with existing admin page (`#1a1a1a` bg, `#404040` borders, `#00ff32` accent)
- Empty states for all sub-components when no data exists yet
- Shared TypeScript types and tooltip styles across chart components

## Test Plan
- [x] Backend: 3 new tests (auth guard, empty DB defaults, computed values) — all passing
- [x] Existing auth tests: 13 tests still passing
- [x] Frontend lint: 0 errors
- [x] Frontend build: successful
- [ ] Manual: verify dashboard renders on `/admin` with real data
- [ ] Manual: verify empty states display correctly with no training runs

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Data Flywheel" admin dashboard: interactive diagram, corpus composition chart, time-series charts, and model-version table.
  * Added an admin-only metrics API powering the dashboard (aggregated corpus, training-run, and research-quality time series).

* **Tests**
  * Added test coverage for the new metrics endpoint: auth, empty-state, and aggregation scenarios.

* **Chores**
  * Introduced/updated test fixtures to mock runtime settings for tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->