### PR TITLE
feat: persist research job crawled content into document schema

### DIFF
--- a/docs/superpowers/plans/2026-04-06-searxng-warmup.md
+++ b/docs/superpowers/plans/2026-04-06-searxng-warmup.md
@@ -1,0 +1,573 @@
+# SearXNG Pre-Warm Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pre-warm SearXNG on Fly.io before crew kickoff so the first search succeeds, and show a phase-aware warmup state in the frontend.
+
+**Architecture:** Add an async `httpx` health check ping to `run_research_job` before crew kickoff. Introduce a `phase` field on all WebSocket progress messages so the frontend can distinguish warmup/init/research/evaluation stages. ProgressCard renders an amber pulsing indicator during warmup.
+
+**Tech Stack:** Python (httpx, asyncio), TypeScript (React, Next.js), Tailwind CSS
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `src/d4bl/services/research_runner.py` | Warmup ping + phase on all progress messages |
+| Modify | `ui-nextjs/lib/types.ts` | Add `phase?` to `WsProgressMessage` |
+| Modify | `ui-nextjs/app/page.tsx` | Track phase state, pass to ProgressCard, reset on complete/error |
+| Modify | `ui-nextjs/components/ProgressCard.tsx` | Amber warmup visual state, accept phase prop |
+| Create | `tests/test_warmup.py` | Backend tests for warmup + phase behavior |
+
+---
+
+### Task 1: Add `phase` to WebSocket progress type
+
+**Files:**
+- Modify: `ui-nextjs/lib/types.ts:58`
+
+- [ ] **Step 1: Add `phase` to `WsProgressMessage`**
+
+In `ui-nextjs/lib/types.ts`, change line 58 from:
+
+```typescript
+export interface WsProgressMessage { type: 'progress'; message: string; logs?: string[] }
+```
+
+to:
+
+```typescript
+export interface WsProgressMessage { type: 'progress'; message: string; phase?: string; logs?: string[] }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui-nextjs/lib/types.ts
+git commit -m "feat(types): add phase field to WsProgressMessage (#173)"
+```
+
+---
+
+### Task 2: Write backend tests for warmup and phase
+
+**Files:**
+- Create: `tests/test_warmup.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_warmup.py`:
+
+```python
+"""Tests for SearXNG warmup and phase-aware progress messages."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def mock_websocket_updates():
+    """Capture all WebSocket updates sent during a job."""
+    updates = []
+    original_send = None
+
+    async def capture_update(job_id, data):
+        updates.append(data)
+
+    return updates, capture_update
+
+
+@pytest.fixture
+def mock_settings_searxng():
+    """Settings with SearXNG configured."""
+    settings = MagicMock()
+    settings.searxng_base_url = "http://searxng:8080"
+    settings.search_provider = "searxng"
+    return settings
+
+
+@pytest.fixture
+def mock_settings_no_searxng():
+    """Settings with SearXNG NOT configured (different provider)."""
+    settings = MagicMock()
+    settings.searxng_base_url = "http://searxng:8080"
+    settings.search_provider = "google"
+    return settings
+
+
+class TestWarmupPing:
+    """Test the SearXNG warmup ping behavior."""
+
+    @pytest.mark.asyncio
+    async def test_warmup_pings_healthz(self, mock_settings_searxng):
+        """Warmup sends GET to SEARXNG_BASE_URL/healthz."""
+        from d4bl.services.research_runner import warmup_searxng
+
+        with patch("d4bl.services.research_runner.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=MagicMock(status_code=200))
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await warmup_searxng(mock_settings_searxng)
+
+            mock_client.get.assert_called_once_with(
+                "http://searxng:8080/healthz", timeout=15.0
+            )
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_warmup_skipped_when_not_searxng(self, mock_settings_no_searxng):
+        """Warmup is skipped when search_provider != 'searxng'."""
+        from d4bl.services.research_runner import warmup_searxng
+
+        with patch("d4bl.services.research_runner.httpx.AsyncClient") as MockClient:
+            result = await warmup_searxng(mock_settings_no_searxng)
+
+            MockClient.assert_not_called()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_warmup_skipped_when_url_empty(self):
+        """Warmup is skipped when searxng_base_url is empty."""
+        from d4bl.services.research_runner import warmup_searxng
+
+        settings = MagicMock()
+        settings.searxng_base_url = ""
+        settings.search_provider = "searxng"
+
+        with patch("d4bl.services.research_runner.httpx.AsyncClient") as MockClient:
+            result = await warmup_searxng(settings)
+
+            MockClient.assert_not_called()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_warmup_handles_timeout(self, mock_settings_searxng):
+        """Warmup returns False on timeout but does not raise."""
+        from d4bl.services.research_runner import warmup_searxng
+
+        with patch("d4bl.services.research_runner.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await warmup_searxng(mock_settings_searxng)
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_warmup_handles_connection_error(self, mock_settings_searxng):
+        """Warmup returns False on connection error but does not raise."""
+        from d4bl.services.research_runner import warmup_searxng
+
+        with patch("d4bl.services.research_runner.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(
+                side_effect=httpx.ConnectError("connection refused")
+            )
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await warmup_searxng(mock_settings_searxng)
+
+            assert result is False
+
+
+class TestPhaseInProgress:
+    """Test that progress messages include the phase field."""
+
+    @pytest.mark.asyncio
+    async def test_notify_progress_includes_phase(self):
+        """notify_progress sends phase in WebSocket update."""
+        captured = []
+
+        async def fake_send(job_id, data):
+            captured.append(data)
+
+        mock_db = AsyncMock()
+
+        async def fake_get_db():
+            yield mock_db
+
+        with patch(
+            "d4bl.services.research_runner.send_websocket_update", side_effect=fake_send
+        ), patch(
+            "d4bl.services.research_runner.update_job_status", new_callable=AsyncMock
+        ), patch(
+            "d4bl.services.research_runner.get_db", fake_get_db
+        ):
+            from d4bl.services.research_runner import _make_notify_progress
+
+            notify = _make_notify_progress("test-job-id", None)
+            await notify("Warming up search services...", phase="warmup")
+
+            assert len(captured) == 1
+            msg = captured[0]
+            assert msg["phase"] == "warmup"
+            assert msg["message"] == "Warming up search services..."
+            assert msg["type"] == "progress"
+
+    @pytest.mark.asyncio
+    async def test_notify_progress_omits_phase_when_none(self):
+        """notify_progress does not include phase key when phase is None."""
+        captured = []
+
+        async def fake_send(job_id, data):
+            captured.append(data)
+
+        mock_db = AsyncMock()
+
+        async def fake_get_db():
+            yield mock_db
+
+        with patch(
+            "d4bl.services.research_runner.send_websocket_update", side_effect=fake_send
+        ), patch(
+            "d4bl.services.research_runner.update_job_status", new_callable=AsyncMock
+        ), patch(
+            "d4bl.services.research_runner.get_db", fake_get_db
+        ):
+            from d4bl.services.research_runner import _make_notify_progress
+
+            notify = _make_notify_progress("test-job-id", None)
+            await notify("Some progress message")
+
+            assert len(captured) == 1
+            assert "phase" not in captured[0]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/william-meroxa/Development/d4bl_ai_agent && python -m pytest tests/test_warmup.py -v`
+
+Expected: FAIL — `warmup_searxng` and `_make_notify_progress` do not exist yet.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/test_warmup.py
+git commit -m "test: add failing tests for SearXNG warmup and phase progress (#173)"
+```
+
+---
+
+### Task 3: Implement backend warmup and phase-aware progress
+
+**Files:**
+- Modify: `src/d4bl/services/research_runner.py`
+
+- [ ] **Step 1: Add httpx import and warmup_searxng function**
+
+At the top of `research_runner.py`, add `httpx` to imports (after the existing import block around line 15):
+
+```python
+import httpx
+```
+
+After the `validate_research_relevance` function (after line 88), add:
+
+```python
+async def warmup_searxng(settings) -> bool:
+    """Ping SearXNG /healthz to wake Fly.io machine. Returns True if healthy."""
+    if settings.search_provider != "searxng" or not settings.searxng_base_url:
+        return False
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{settings.searxng_base_url}/healthz", timeout=15.0
+            )
+            logger.info("SearXNG warmup: %s (status %d)", settings.searxng_base_url, resp.status_code)
+            return True
+    except (httpx.TimeoutException, httpx.ConnectError, httpx.HTTPError) as exc:
+        logger.warning("SearXNG warmup failed (will proceed anyway): %s", exc)
+        return False
+```
+
+- [ ] **Step 2: Extract `_make_notify_progress` factory and add phase support**
+
+The existing `notify_progress` is a closure inside `run_research_job`. Extract a factory so it can be tested and accepts a `phase` parameter.
+
+After the `warmup_searxng` function, add:
+
+```python
+def _make_notify_progress(job_id: str, trace_id_hex: str | None):
+    """Create a notify_progress coroutine for a given job. Testable factory."""
+
+    async def notify_progress(progress_msg: str, phase: str | None = None) -> None:
+        """Update DB status and push progress via WebSocket in one call."""
+        async for db in get_db():
+            try:
+                await update_job_status(db, job_id, "running", progress=progress_msg)
+                break
+            except Exception as update_err:
+                print(f"Error updating job status: {update_err}")
+                break
+
+        ws_payload = {
+            "type": "progress",
+            "job_id": job_id,
+            "status": "running",
+            "message": progress_msg,
+            "progress": progress_msg,
+            "trace_id": trace_id_hex,
+        }
+        if phase is not None:
+            ws_payload["phase"] = phase
+        await send_websocket_update(job_id, ws_payload)
+
+    return notify_progress
+```
+
+Note: The payload includes both `"message"` (matches the frontend `WsProgressMessage` type) and `"progress"` (used by the polling fallback path).
+
+- [ ] **Step 3: Update `run_research_job` to use the factory and add warmup**
+
+Three changes inside `run_research_job`:
+
+**3a. Keep `set_status` closure as-is** (lines 201-229). It's used for final status updates — do not modify it.
+
+**3b. Delete the old `notify_progress` closure** (lines 231-244) and replace with:
+
+```python
+            notify_progress = _make_notify_progress(job_id, trace_id_hex)
+```
+
+**3c. Replace the init sequence** (lines 250-258, starting at `await notify_progress("Initializing research crew...")`) with:
+
+```python
+            # -- Warmup SearXNG (wakes Fly.io machine) --
+            from d4bl.settings import get_settings
+
+            settings = get_settings()
+            if settings.search_provider == "searxng" and settings.searxng_base_url:
+                await notify_progress("Warming up search services...", phase="warmup")
+                await warmup_searxng(settings)
+
+            await notify_progress("Initializing research crew...", phase="init")
+
+            inputs = {
+                "query": query,
+                "summary_format": summary_format,
+                "current_year": str(datetime.now().year),
+            }
+
+            await notify_progress("Starting research task...", phase="research")
+```
+
+- [ ] **Step 4: Tag remaining progress messages with phases**
+
+Find the remaining `notify_progress` calls in the function and add phases:
+
+1. Line ~344 (after crew execution): change `await notify_progress("Research completed, processing results...")` to:
+   ```python
+   await notify_progress("Research completed, processing results...", phase="evaluation")
+   ```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/william-meroxa/Development/d4bl_ai_agent && python -m pytest tests/test_warmup.py -v`
+
+Expected: All 7 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/d4bl/services/research_runner.py
+git commit -m "feat(backend): add SearXNG warmup ping and phase-aware progress (#173)"
+```
+
+---
+
+### Task 4: Frontend phase tracking in page.tsx
+
+**Files:**
+- Modify: `ui-nextjs/app/page.tsx`
+
+- [ ] **Step 1: Add phase state**
+
+After the existing `useState` declarations (around line 28), add:
+
+```typescript
+const [phase, setPhase] = useState<string | null>(null);
+```
+
+- [ ] **Step 2: Extract phase from progress messages**
+
+In the WebSocket message handler's `'progress'` case (line 53-55), change:
+
+```typescript
+          case 'progress':
+            updateLogs(data);
+            setProgress(data.message || 'Processing...');
+            break;
+```
+
+to:
+
+```typescript
+          case 'progress':
+            updateLogs(data);
+            setProgress(data.message || 'Processing...');
+            setPhase(data.phase ?? null);
+            break;
+```
+
+- [ ] **Step 3: Reset phase on complete and error**
+
+In the `'complete'` case (line 56-60), add `setPhase(null)` after `setResults`:
+
+```typescript
+          case 'complete':
+            updateLogs(data);
+            setProgress('Research completed!');
+            setResults(data.result);
+            setPhase(null);
+            setJobId(null);
+            break;
+```
+
+In the `'error'` case (line 61-64), add `setPhase(null)` after `setError`:
+
+```typescript
+          case 'error':
+            updateLogs(data);
+            setError(data.error || data.message || 'An error occurred during research');
+            setPhase(null);
+            setJobId(null);
+            break;
+```
+
+- [ ] **Step 4: Pass phase to ProgressCard**
+
+In the JSX (around line 253), change:
+
+```tsx
+                  <ProgressCard
+                    progress={progress}
+                    isConnected={isConnected}
+                  />
+```
+
+to:
+
+```tsx
+                  <ProgressCard
+                    progress={progress}
+                    isConnected={isConnected}
+                    phase={phase}
+                  />
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui-nextjs/app/page.tsx
+git commit -m "feat(frontend): track phase state from WebSocket progress messages (#173)"
+```
+
+---
+
+### Task 5: ProgressCard warmup visual state
+
+**Files:**
+- Modify: `ui-nextjs/components/ProgressCard.tsx`
+
+- [ ] **Step 1: Update ProgressCard to accept phase and render warmup state**
+
+Replace the entire contents of `ui-nextjs/components/ProgressCard.tsx` with:
+
+```tsx
+'use client';
+
+interface ProgressCardProps {
+  progress: string;
+  isConnected: boolean;
+  phase?: string | null;
+}
+
+export default function ProgressCard({ progress, isConnected, phase }: ProgressCardProps) {
+  const isWarmup = phase === 'warmup';
+
+  // Dot: amber pulsing during warmup, green when connected, red when disconnected
+  const dotClass = isWarmup
+    ? 'bg-amber-500 animate-pulse'
+    : isConnected
+      ? 'bg-[#00ff32]'
+      : 'bg-red-500';
+
+  const statusLabel = isWarmup
+    ? 'Warming up...'
+    : isConnected
+      ? 'Connected'
+      : 'Disconnected';
+
+  // Progress bar: amber during warmup, green otherwise
+  const barClass = isWarmup
+    ? 'bg-amber-500/50 h-2 rounded-full w-full animate-pulse'
+    : 'bg-[#00ff32]/50 h-2 rounded-full w-full animate-pulse';
+
+  return (
+    <div className="bg-[#333333] border border-[#404040] rounded-lg p-8 shadow-sm">
+      <h2 className="text-2xl font-bold text-white mb-6">
+        Research Progress
+      </h2>
+      <div className="space-y-4">
+        <div className="w-full bg-[#1a1a1a] rounded-full h-2">
+          <div className={barClass} />
+        </div>
+        <div className="flex items-center justify-between">
+          <p className="text-gray-200 font-medium">{progress || 'Processing...'}</p>
+          <div className="flex items-center space-x-2">
+            <div className={`w-2 h-2 rounded-full ${dotClass}`} />
+            <span className="text-sm text-gray-300 font-medium">
+              {statusLabel}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui-nextjs/components/ProgressCard.tsx
+git commit -m "feat(frontend): add amber warmup state to ProgressCard (#173)"
+```
+
+---
+
+### Task 6: Build verification
+
+- [ ] **Step 1: Run backend tests**
+
+Run: `cd /Users/william-meroxa/Development/d4bl_ai_agent && python -m pytest tests/test_warmup.py -v`
+
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run frontend lint**
+
+Run: `cd /Users/william-meroxa/Development/d4bl_ai_agent/ui-nextjs && npm run lint`
+
+Expected: No errors.
+
+- [ ] **Step 3: Run frontend build**
+
+Run: `cd /Users/william-meroxa/Development/d4bl_ai_agent/ui-nextjs && npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Fix any issues and commit**
+
+If any step fails, fix the issue and commit the fix.

--- a/docs/superpowers/plans/2026-04-07-cost-tracking.md
+++ b/docs/superpowers/plans/2026-04-07-cost-tracking.md
@@ -1,0 +1,1260 @@
+# LLM Cost Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track LLM token usage and estimated cost per research job, display per-job costs on ResultsCard, and show aggregate cost metrics on the admin page.
+
+**Architecture:** Add a `usage` JSONB column to the `ResearchJob` table. After CrewAI's `kickoff()` returns a `CrewOutput` object, extract its `token_usage` attribute (a `UsageMetrics` Pydantic model with `total_tokens`, `prompt_tokens`, `completion_tokens`, `cached_prompt_tokens`, `successful_requests`). Calculate estimated cost using a simple per-model rate table (since the project uses Ollama locally and Gemini via LiteLLM, not OpenAI). Store the usage dict in the new column and expose it through the existing job status API and a new admin costs endpoint.
+
+**Tech Stack:** Python (FastAPI, SQLAlchemy, CrewAI 1.5.0), TypeScript (Next.js, React 19), PostgreSQL (JSONB)
+
+**Key Reference Files:**
+- `src/d4bl/infra/database.py` -- ResearchJob model (line 39-81)
+- `src/d4bl/services/research_runner.py` -- crew kickoff + result processing (line 399-427 for kickoff, line 448-792 for result handling)
+- `src/d4bl/app/api.py` -- GET /api/jobs/{id} (line 642-653), admin endpoints (line 1963+)
+- `src/d4bl/app/schemas.py` -- JobStatus schema (line 34-47)
+- `ui-nextjs/components/ResultsCard.tsx` -- research results display
+- `ui-nextjs/app/admin/page.tsx` -- admin dashboard
+- `ui-nextjs/lib/types.ts` -- frontend type definitions
+- `ui-nextjs/lib/api.ts` -- API client functions and types
+- CrewAI source: `.venv/.../crewai/crews/crew_output.py` -- CrewOutput has `token_usage: UsageMetrics`
+- CrewAI source: `.venv/.../crewai/types/usage_metrics.py` -- fields: `total_tokens`, `prompt_tokens`, `cached_prompt_tokens`, `completion_tokens`, `successful_requests`
+
+---
+
+### Task 1: Add `usage` JSONB column to ResearchJob model and create migration
+
+**Files:**
+- Modify: `src/d4bl/infra/database.py`
+- Create: `supabase/migrations/20260407000001_add_usage_column.sql`
+- Modify: `tests/test_database.py`
+
+- [ ] **Step 1: Write test for the new `usage` column**
+
+In `tests/test_database.py`, add a test verifying the `usage` column exists on `ResearchJob` and is JSONB type:
+
+```python
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+class TestUsageColumn:
+    """Verify the usage JSONB column on ResearchJob."""
+
+    def test_research_job_has_usage_column(self):
+        col = ResearchJob.__table__.columns["usage"]
+        assert col is not None
+
+    def test_usage_column_is_jsonb(self):
+        col = ResearchJob.__table__.columns["usage"]
+        assert isinstance(col.type, JSONB)
+
+    def test_usage_column_is_nullable(self):
+        col = ResearchJob.__table__.columns["usage"]
+        assert col.nullable is True
+
+    def test_to_dict_includes_usage(self):
+        job = ResearchJob()
+        job.job_id = uuid4()
+        job.query = "test"
+        job.summary_format = "detailed"
+        job.status = "pending"
+        job.usage = {"total_tokens": 100, "estimated_cost_usd": 0.001}
+        d = job.to_dict()
+        assert d["usage"] == {"total_tokens": 100, "estimated_cost_usd": 0.001}
+
+    def test_to_dict_usage_none_when_unset(self):
+        job = ResearchJob()
+        job.job_id = uuid4()
+        job.query = "test"
+        job.summary_format = "detailed"
+        job.status = "pending"
+        d = job.to_dict()
+        assert d["usage"] is None
+```
+
+Add the necessary import at the top of `tests/test_database.py`:
+
+```python
+from uuid import uuid4
+```
+
+**Test command:** `python -m pytest tests/test_database.py::TestUsageColumn -v`
+
+- [ ] **Step 2: Add `usage` column to ResearchJob model**
+
+In `src/d4bl/infra/database.py`, add the `usage` column to the `ResearchJob` class after the `user_id` column (line 62):
+
+```python
+    # No ForeignKey -- auth.users is managed by Supabase, not SQLAlchemy
+    user_id = Column(PG_UUID(as_uuid=True), nullable=True, index=True)
+    usage = Column(JSONB, nullable=True)  # LLM token usage and cost per job
+```
+
+- [ ] **Step 3: Update `to_dict` to include `usage`**
+
+In `src/d4bl/infra/database.py`, update the `to_dict` method of `ResearchJob` to include the new field. Add after the `"user_id"` line (line 81):
+
+```python
+    def to_dict(self):
+        """Convert model to dictionary"""
+        return {
+            "job_id": str(self.job_id),
+            "trace_id": self.trace_id,
+            "query": self.query,
+            "summary_format": self.summary_format,
+            "status": self.status,
+            "progress": self.progress,
+            "result": self.result,
+            "research_data": self.research_data,
+            "error": self.error,
+            "logs": self.logs,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "user_id": str(self.user_id) if self.user_id else None,
+            "usage": self.usage,
+        }
+```
+
+- [ ] **Step 4: Create SQL migration**
+
+Create `supabase/migrations/20260407000001_add_usage_column.sql`:
+
+```sql
+-- Add JSONB column to track LLM token usage and estimated cost per research job.
+ALTER TABLE research_jobs ADD COLUMN IF NOT EXISTS usage JSONB;
+
+COMMENT ON COLUMN research_jobs.usage IS
+  'LLM token usage and cost: {prompt_tokens, completion_tokens, total_tokens, estimated_cost_usd, model}';
+```
+
+**Test command:** `python -m pytest tests/test_database.py -v`
+
+**Commit:** `git commit -m "feat(infra): add usage JSONB column to ResearchJob for cost tracking"`
+
+---
+
+### Task 2: Extract token usage from CrewAI result and store in database
+
+**Files:**
+- Create: `src/d4bl/services/cost_tracker.py`
+- Modify: `src/d4bl/services/research_runner.py`
+- Create: `tests/test_cost_tracker.py`
+- Modify: `tests/test_warmup.py` (if it tests `update_job_status`)
+
+- [ ] **Step 1: Write tests for cost_tracker module**
+
+Create `tests/test_cost_tracker.py`:
+
+```python
+"""Tests for the cost tracker utility."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+
+class TestExtractUsageMetrics:
+    """Verify extraction of token usage from a CrewAI result."""
+
+    def test_extracts_token_counts_from_crew_output(self):
+        from d4bl.services.cost_tracker import extract_usage
+
+        mock_usage = MagicMock()
+        mock_usage.total_tokens = 1500
+        mock_usage.prompt_tokens = 1000
+        mock_usage.completion_tokens = 500
+        mock_usage.cached_prompt_tokens = 50
+        mock_usage.successful_requests = 5
+
+        mock_result = MagicMock()
+        mock_result.token_usage = mock_usage
+
+        usage = extract_usage(mock_result, model="ollama/qwen2.5:3b")
+
+        assert usage["total_tokens"] == 1500
+        assert usage["prompt_tokens"] == 1000
+        assert usage["completion_tokens"] == 500
+        assert usage["cached_prompt_tokens"] == 50
+        assert usage["successful_requests"] == 5
+        assert usage["model"] == "ollama/qwen2.5:3b"
+
+    def test_returns_none_when_no_token_usage(self):
+        from d4bl.services.cost_tracker import extract_usage
+
+        mock_result = MagicMock(spec=[])  # no token_usage attribute
+
+        usage = extract_usage(mock_result, model="ollama/qwen2.5:3b")
+        assert usage is None
+
+    def test_returns_none_when_token_usage_is_none(self):
+        from d4bl.services.cost_tracker import extract_usage
+
+        mock_result = MagicMock()
+        mock_result.token_usage = None
+
+        usage = extract_usage(mock_result, model="ollama/qwen2.5:3b")
+        assert usage is None
+
+    def test_returns_none_when_all_tokens_zero(self):
+        from d4bl.services.cost_tracker import extract_usage
+
+        mock_usage = MagicMock()
+        mock_usage.total_tokens = 0
+        mock_usage.prompt_tokens = 0
+        mock_usage.completion_tokens = 0
+        mock_usage.cached_prompt_tokens = 0
+        mock_usage.successful_requests = 0
+
+        mock_result = MagicMock()
+        mock_result.token_usage = mock_usage
+
+        usage = extract_usage(mock_result, model="ollama/qwen2.5:3b")
+        assert usage is None
+
+
+class TestEstimateCost:
+    """Verify cost estimation logic."""
+
+    def test_ollama_local_models_are_free(self):
+        from d4bl.services.cost_tracker import estimate_cost_usd
+
+        cost = estimate_cost_usd(
+            prompt_tokens=10000,
+            completion_tokens=5000,
+            model="ollama/qwen2.5:3b",
+        )
+        assert cost == 0.0
+
+    def test_gemini_flash_cost(self):
+        from d4bl.services.cost_tracker import estimate_cost_usd
+
+        # Gemini 2.5 Flash: $0.15/1M input, $0.60/1M output (as of 2025)
+        cost = estimate_cost_usd(
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+            model="gemini/gemini-2.5-flash",
+        )
+        assert cost == pytest.approx(0.75, abs=0.01)
+
+    def test_unknown_model_returns_zero(self):
+        from d4bl.services.cost_tracker import estimate_cost_usd
+
+        cost = estimate_cost_usd(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            model="unknown/model",
+        )
+        assert cost == 0.0
+
+    def test_extract_usage_includes_estimated_cost(self):
+        from d4bl.services.cost_tracker import extract_usage
+
+        mock_usage = MagicMock()
+        mock_usage.total_tokens = 2_000_000
+        mock_usage.prompt_tokens = 1_000_000
+        mock_usage.completion_tokens = 1_000_000
+        mock_usage.cached_prompt_tokens = 0
+        mock_usage.successful_requests = 10
+
+        mock_result = MagicMock()
+        mock_result.token_usage = mock_usage
+
+        usage = extract_usage(mock_result, model="gemini/gemini-2.5-flash")
+
+        assert "estimated_cost_usd" in usage
+        assert usage["estimated_cost_usd"] > 0
+
+    def test_extract_usage_ollama_cost_is_zero(self):
+        from d4bl.services.cost_tracker import extract_usage
+
+        mock_usage = MagicMock()
+        mock_usage.total_tokens = 5000
+        mock_usage.prompt_tokens = 3000
+        mock_usage.completion_tokens = 2000
+        mock_usage.cached_prompt_tokens = 0
+        mock_usage.successful_requests = 3
+
+        mock_result = MagicMock()
+        mock_result.token_usage = mock_usage
+
+        usage = extract_usage(mock_result, model="ollama/llama3")
+
+        assert usage["estimated_cost_usd"] == 0.0
+```
+
+**Test command:** `python -m pytest tests/test_cost_tracker.py -v`
+
+- [ ] **Step 2: Implement cost_tracker module**
+
+Create `src/d4bl/services/cost_tracker.py`:
+
+```python
+"""
+Utility for extracting LLM token usage from CrewAI results and estimating cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Per-million-token pricing. Local Ollama models are free.
+# Format: model_prefix -> (input_cost_per_1M, output_cost_per_1M)
+_MODEL_COSTS: dict[str, tuple[float, float]] = {
+    "ollama/": (0.0, 0.0),
+    "gemini/gemini-2.5-flash": (0.15, 0.60),
+    "gemini/gemini-2.5-pro": (1.25, 10.00),
+    "gemini/gemini-2.0-flash": (0.10, 0.40),
+    "gemini/gemini-1.5-flash": (0.075, 0.30),
+    "gemini/gemini-1.5-pro": (1.25, 5.00),
+}
+
+
+def estimate_cost_usd(
+    prompt_tokens: int,
+    completion_tokens: int,
+    model: str,
+) -> float:
+    """Estimate USD cost based on token counts and model name.
+
+    Uses a prefix-match lookup table. Returns 0.0 for unknown or local models.
+    """
+    model_lower = model.lower() if model else ""
+
+    # Try exact match first, then prefix match (longest prefix wins)
+    matched_cost: tuple[float, float] | None = None
+    matched_len = 0
+
+    for prefix, costs in _MODEL_COSTS.items():
+        if model_lower.startswith(prefix) and len(prefix) > matched_len:
+            matched_cost = costs
+            matched_len = len(prefix)
+
+    if matched_cost is None:
+        return 0.0
+
+    input_cost_per_m, output_cost_per_m = matched_cost
+    cost = (prompt_tokens / 1_000_000) * input_cost_per_m + (
+        completion_tokens / 1_000_000
+    ) * output_cost_per_m
+    return round(cost, 6)
+
+
+def extract_usage(result: Any, model: str) -> dict[str, Any] | None:
+    """Extract token usage from a CrewAI CrewOutput and compute estimated cost.
+
+    Returns a dict suitable for storing in the ``usage`` JSONB column, or None
+    if no meaningful usage data is available.
+    """
+    token_usage = getattr(result, "token_usage", None)
+    if token_usage is None:
+        return None
+
+    total = getattr(token_usage, "total_tokens", 0) or 0
+    prompt = getattr(token_usage, "prompt_tokens", 0) or 0
+    completion = getattr(token_usage, "completion_tokens", 0) or 0
+    cached = getattr(token_usage, "cached_prompt_tokens", 0) or 0
+    requests = getattr(token_usage, "successful_requests", 0) or 0
+
+    if total == 0 and prompt == 0 and completion == 0:
+        return None
+
+    cost = estimate_cost_usd(prompt, completion, model)
+
+    return {
+        "total_tokens": total,
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "cached_prompt_tokens": cached,
+        "successful_requests": requests,
+        "estimated_cost_usd": cost,
+        "model": model,
+    }
+```
+
+**Test command:** `python -m pytest tests/test_cost_tracker.py -v`
+
+- [ ] **Step 3: Wire cost extraction into research_runner.py**
+
+In `src/d4bl/services/research_runner.py`, add the import near the top (after line 37):
+
+```python
+from d4bl.services.cost_tracker import extract_usage
+```
+
+Then, after the crew result is obtained and before the evaluation section (after line 427, where `sys.stdout` is restored), add usage extraction. Insert after the line `await notify_progress("Research completed, processing results...", phase="evaluation")` (line 448):
+
+```python
+            # Extract LLM token usage from CrewAI result
+            usage_dict: dict | None = None
+            try:
+                model_name = model or settings.ollama_model or "ollama/unknown"
+                usage_dict = extract_usage(result, model=model_name)
+                if usage_dict:
+                    logger.info(
+                        "Token usage: %d total (%d prompt + %d completion), est. $%.4f",
+                        usage_dict["total_tokens"],
+                        usage_dict["prompt_tokens"],
+                        usage_dict["completion_tokens"],
+                        usage_dict["estimated_cost_usd"],
+                    )
+            except Exception as usage_err:
+                logger.warning("Failed to extract token usage: %s", usage_err)
+```
+
+- [ ] **Step 4: Update `update_job_status` to accept and store `usage`**
+
+In `src/d4bl/services/research_runner.py`, update the `update_job_status` function signature (line 239) to accept `usage`:
+
+```python
+async def update_job_status(
+    db: AsyncSession,
+    job_id: str,
+    status: str,
+    progress: str | None = None,
+    result: dict | None = None,
+    research_data: dict | None = None,
+    error: str | None = None,
+    logs: list[str] | None = None,
+    trace_id: str | None = None,
+    evaluation_results: dict | None = None,
+    usage: dict | None = None,
+) -> None:
+```
+
+Inside the function body, after the `trace_id` assignment (after line 275), add:
+
+```python
+        if usage is not None:
+            job.usage = usage
+```
+
+- [ ] **Step 5: Pass `usage_dict` through `set_status` and the final status update**
+
+In `src/d4bl/services/research_runner.py`, update the inner `set_status` function (around line 304) to accept and forward `usage`:
+
+```python
+    async def set_status(
+        progress_msg: str | None,
+        status: str = "running",
+        result: dict | None = None,
+        research_data: dict | None = None,
+        error: str | None = None,
+        logs: list[str] | None = None,
+        trace_override: str | None = None,
+        evaluation_results: dict | None = None,
+        usage: dict | None = None,
+    ) -> None:
+        trace_value = trace_override or trace_id_hex
+        async for db in get_db():
+            try:
+                await update_job_status(
+                    db,
+                    job_id,
+                    status,
+                    progress=progress_msg,
+                    result=result,
+                    research_data=research_data,
+                    error=error,
+                    logs=logs,
+                    trace_id=trace_value,
+                    evaluation_results=evaluation_results,
+                    usage=usage,
+                )
+                break
+            except Exception as update_err:  # noqa: BLE001
+                print(f"Error updating job status: {update_err}")
+                break
+```
+
+Then update the final `set_status` call (around line 785) to include `usage=usage_dict`:
+
+```python
+            await set_status(
+                "Research completed successfully!",
+                status="completed",
+                result=result_dict,
+                research_data=research_data_dict,
+                logs=final_logs,
+                evaluation_results=evaluation_results,
+                usage=usage_dict,
+            )
+```
+
+**Test command:** `python -m pytest tests/test_cost_tracker.py tests/test_database.py -v`
+
+**Commit:** `git commit -m "feat(services): extract CrewAI token usage and estimate cost per job"`
+
+---
+
+### Task 3: Add `usage` to the JobStatus schema so it appears in API responses
+
+**Files:**
+- Modify: `src/d4bl/app/schemas.py`
+- Modify: `ui-nextjs/lib/api.ts`
+- Modify: `tests/test_app_schemas.py`
+
+- [ ] **Step 1: Write test for the schema change**
+
+In `tests/test_app_schemas.py`, add a test (append to the file):
+
+```python
+class TestJobStatusUsage:
+    """Verify usage field is included in JobStatus schema."""
+
+    def test_job_status_accepts_usage_dict(self):
+        from d4bl.app.schemas import JobStatus
+
+        status = JobStatus(
+            job_id="abc-123",
+            status="completed",
+            usage={
+                "total_tokens": 1500,
+                "prompt_tokens": 1000,
+                "completion_tokens": 500,
+                "estimated_cost_usd": 0.003,
+                "model": "ollama/qwen2.5:3b",
+            },
+        )
+        assert status.usage["total_tokens"] == 1500
+        assert status.usage["estimated_cost_usd"] == 0.003
+
+    def test_job_status_usage_defaults_to_none(self):
+        from d4bl.app.schemas import JobStatus
+
+        status = JobStatus(job_id="abc-123", status="pending")
+        assert status.usage is None
+```
+
+**Test command:** `python -m pytest tests/test_app_schemas.py::TestJobStatusUsage -v`
+
+- [ ] **Step 2: Add `usage` field to `JobStatus` schema**
+
+In `src/d4bl/app/schemas.py`, add `usage` to the `JobStatus` class (after `completed_at` on line 47):
+
+```python
+class JobStatus(BaseModel):
+    job_id: str
+    trace_id: str | None = None
+    status: str  # pending, running, completed, error
+    progress: str | None = None
+    result: dict | None = None
+    error: str | None = None
+    query: str | None = None
+    summary_format: str | None = None
+    logs: list[str] | None = None
+    research_data: dict | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    completed_at: str | None = None
+    usage: dict | None = None
+```
+
+- [ ] **Step 3: Update frontend `JobStatus` type in `ui-nextjs/lib/api.ts`**
+
+In `ui-nextjs/lib/api.ts`, add `usage` to the `JobStatus` interface (after `completed_at`, around line 75):
+
+```typescript
+export interface JobStatus {
+  job_id: string;
+  trace_id?: string;
+  status: 'pending' | 'running' | 'completed' | 'error';
+  progress?: string;
+  result?: ResearchResult;
+  error?: string;
+  query?: string;
+  summary_format?: string;
+  logs?: string[];
+  created_at?: string;
+  updated_at?: string;
+  completed_at?: string;
+  usage?: {
+    total_tokens: number;
+    prompt_tokens: number;
+    completion_tokens: number;
+    cached_prompt_tokens?: number;
+    successful_requests?: number;
+    estimated_cost_usd: number;
+    model: string;
+  };
+}
+```
+
+**Test command:** `python -m pytest tests/test_app_schemas.py -v`
+
+**Commit:** `git commit -m "feat(api): include usage in JobStatus schema for cost visibility"`
+
+---
+
+### Task 4: Add admin costs API endpoint
+
+**Files:**
+- Modify: `src/d4bl/app/api.py`
+- Modify: `src/d4bl/app/schemas.py`
+- Create: `tests/test_admin_costs.py`
+
+- [ ] **Step 1: Write tests for the admin costs endpoint**
+
+Create `tests/test_admin_costs.py`:
+
+```python
+"""Tests for the admin costs endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.conftest import MOCK_ADMIN, MOCK_USER
+
+
+@pytest.fixture
+def admin_client(override_admin_auth):
+    """TestClient authenticated as admin."""
+    return TestClient(override_admin_auth, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def user_client(override_auth):
+    """TestClient authenticated as regular user."""
+    return TestClient(override_auth, raise_server_exceptions=False)
+
+
+class TestAdminCostsEndpoint:
+    """Test GET /api/admin/costs endpoint."""
+
+    def test_requires_admin(self, user_client):
+        """Regular users cannot access the costs endpoint."""
+        response = user_client.get("/api/admin/costs")
+        assert response.status_code in (401, 403)
+
+    @patch("d4bl.app.api.get_db")
+    def test_returns_aggregate_costs(self, mock_get_db, admin_client):
+        """Admin gets aggregate cost stats."""
+        # Mock the database query results
+        mock_db = AsyncMock()
+
+        # Mock for total jobs with usage
+        mock_total_result = MagicMock()
+        mock_total_result.scalar_one.return_value = 5
+
+        # Mock for aggregate sums
+        mock_agg_result = MagicMock()
+        mock_agg_result.one.return_value = (7500, 5000, 2500, 0.015)
+
+        # Mock for recent jobs
+        mock_recent_result = MagicMock()
+        mock_recent_result.mappings.return_value.all.return_value = [
+            {
+                "job_id": str(uuid4()),
+                "query": "test query",
+                "created_at": "2026-04-07T00:00:00",
+                "usage": {
+                    "total_tokens": 1500,
+                    "estimated_cost_usd": 0.003,
+                    "model": "ollama/qwen2.5:3b",
+                },
+            }
+        ]
+
+        call_count = 0
+        async def mock_execute(query, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_total_result
+            elif call_count == 2:
+                return mock_agg_result
+            else:
+                return mock_recent_result
+
+        mock_db.execute = mock_execute
+
+        async def mock_db_gen():
+            yield mock_db
+
+        mock_get_db.return_value = mock_db_gen()
+
+        response = admin_client.get("/api/admin/costs")
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_jobs_with_usage" in data
+        assert "total_tokens" in data
+        assert "total_estimated_cost_usd" in data
+        assert "recent_jobs" in data
+
+    @patch("d4bl.app.api.get_db")
+    def test_returns_zeros_when_no_jobs_have_usage(self, mock_get_db, admin_client):
+        """Returns zero aggregates when no jobs have usage data."""
+        mock_db = AsyncMock()
+
+        mock_total_result = MagicMock()
+        mock_total_result.scalar_one.return_value = 0
+
+        mock_agg_result = MagicMock()
+        mock_agg_result.one.return_value = (None, None, None, None)
+
+        mock_recent_result = MagicMock()
+        mock_recent_result.mappings.return_value.all.return_value = []
+
+        call_count = 0
+        async def mock_execute(query, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_total_result
+            elif call_count == 2:
+                return mock_agg_result
+            else:
+                return mock_recent_result
+
+        mock_db.execute = mock_execute
+
+        async def mock_db_gen():
+            yield mock_db
+
+        mock_get_db.return_value = mock_db_gen()
+
+        response = admin_client.get("/api/admin/costs")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_jobs_with_usage"] == 0
+        assert data["total_tokens"] == 0
+        assert data["total_estimated_cost_usd"] == 0.0
+```
+
+**Test command:** `python -m pytest tests/test_admin_costs.py -v`
+
+- [ ] **Step 2: Add response schema for admin costs**
+
+In `src/d4bl/app/schemas.py`, add after the `UpdateRoleRequest` class (around line 193):
+
+```python
+class CostSummaryJob(BaseModel):
+    """A recent job entry in the cost summary."""
+
+    job_id: str
+    query: str | None = None
+    created_at: str | None = None
+    total_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    model: str | None = None
+
+
+class CostSummaryResponse(BaseModel):
+    """Aggregate cost stats returned by the admin costs endpoint."""
+
+    total_jobs_with_usage: int = 0
+    total_tokens: int = 0
+    total_prompt_tokens: int = 0
+    total_completion_tokens: int = 0
+    total_estimated_cost_usd: float = 0.0
+    avg_tokens_per_job: float = 0.0
+    avg_cost_per_job: float = 0.0
+    recent_jobs: list[CostSummaryJob] = []
+```
+
+- [ ] **Step 3: Add the admin costs endpoint to api.py**
+
+In `src/d4bl/app/api.py`, add the import for the new schema. Update the import block (around line 39) to include `CostSummaryJob, CostSummaryResponse`:
+
+```python
+from d4bl.app.schemas import (
+    CompareRequest,
+    CompareResponse,
+    CostSummaryJob,
+    CostSummaryResponse,
+    EvalRunItem,
+    # ... rest of imports
+)
+```
+
+Then add the endpoint after the existing admin endpoints (after the ingestion status endpoint, around line 2110):
+
+```python
+# ---------------------------------------------------------------------------
+# Admin cost tracking
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/admin/costs", response_model=CostSummaryResponse)
+async def get_cost_summary(
+    limit: int = 20,
+    user: CurrentUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Aggregate LLM cost stats across all research jobs (admin only)."""
+    limit = max(1, min(limit, 100))
+
+    # Count jobs with non-null usage
+    count_result = await db.execute(
+        text("SELECT count(*) FROM research_jobs WHERE usage IS NOT NULL")
+    )
+    total_jobs = count_result.scalar_one()
+
+    # Aggregate token totals and cost
+    agg_result = await db.execute(
+        text("""
+            SELECT
+                COALESCE(SUM((usage->>'total_tokens')::int), 0),
+                COALESCE(SUM((usage->>'prompt_tokens')::int), 0),
+                COALESCE(SUM((usage->>'completion_tokens')::int), 0),
+                COALESCE(SUM((usage->>'estimated_cost_usd')::numeric), 0)
+            FROM research_jobs
+            WHERE usage IS NOT NULL
+        """)
+    )
+    total_tokens, total_prompt, total_completion, total_cost = agg_result.one()
+
+    total_tokens = total_tokens or 0
+    total_prompt = total_prompt or 0
+    total_completion = total_completion or 0
+    total_cost = float(total_cost or 0)
+
+    avg_tokens = total_tokens / total_jobs if total_jobs > 0 else 0.0
+    avg_cost = total_cost / total_jobs if total_jobs > 0 else 0.0
+
+    # Recent jobs with usage
+    recent_result = await db.execute(
+        text("""
+            SELECT job_id, query, created_at, usage
+            FROM research_jobs
+            WHERE usage IS NOT NULL
+            ORDER BY created_at DESC
+            LIMIT :lim
+        """),
+        {"lim": limit},
+    )
+    recent_rows = recent_result.mappings().all()
+
+    recent_jobs = []
+    for row in recent_rows:
+        usage = row["usage"] or {}
+        recent_jobs.append(
+            CostSummaryJob(
+                job_id=str(row["job_id"]),
+                query=row["query"],
+                created_at=row["created_at"].isoformat() if row["created_at"] else None,
+                total_tokens=usage.get("total_tokens", 0),
+                estimated_cost_usd=usage.get("estimated_cost_usd", 0.0),
+                model=usage.get("model"),
+            )
+        )
+
+    return CostSummaryResponse(
+        total_jobs_with_usage=total_jobs,
+        total_tokens=total_tokens,
+        total_prompt_tokens=total_prompt,
+        total_completion_tokens=total_completion,
+        total_estimated_cost_usd=total_cost,
+        avg_tokens_per_job=round(avg_tokens, 1),
+        avg_cost_per_job=round(avg_cost, 6),
+        recent_jobs=recent_jobs,
+    )
+```
+
+**Test command:** `python -m pytest tests/test_admin_costs.py -v`
+
+**Commit:** `git commit -m "feat(api): add GET /api/admin/costs endpoint for aggregate LLM cost stats"`
+
+---
+
+### Task 5: Display per-job cost on ResultsCard
+
+**Files:**
+- Modify: `ui-nextjs/components/ResultsCard.tsx`
+- Modify: `ui-nextjs/lib/types.ts`
+
+- [ ] **Step 1: Add `usage` to the `ResearchResult` type**
+
+In `ui-nextjs/lib/types.ts`, update the `ResearchResult` interface to include an optional `usage` field:
+
+```typescript
+/** Result payload returned when a research job completes. */
+export interface ResearchResult {
+  report?: string;
+  tasks_output?: ResearchTaskOutput[];
+  raw_output?: string;
+}
+
+/** LLM token usage and cost metadata. */
+export interface UsageMetrics {
+  total_tokens: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cached_prompt_tokens?: number;
+  successful_requests?: number;
+  estimated_cost_usd: number;
+  model: string;
+}
+```
+
+- [ ] **Step 2: Update ResultsCard to accept and display usage**
+
+In `ui-nextjs/components/ResultsCard.tsx`, update the `ResultsCardProps` interface to accept optional `usage` and display it:
+
+```typescript
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import { ResearchResult, ResearchTaskOutput, UsageMetrics } from '@/lib/types';
+
+interface ResultsCardProps {
+  results: ResearchResult;
+  usage?: UsageMetrics | null;
+}
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toString();
+}
+
+function formatCost(usd: number): string {
+  if (usd === 0) return 'free (local)';
+  if (usd < 0.01) return `~$${usd.toFixed(4)}`;
+  return `~$${usd.toFixed(2)}`;
+}
+
+export default function ResultsCard({ results, usage }: ResultsCardProps) {
+```
+
+Then, inside the component's return JSX, add a usage badge after the `<h2>Research Results</h2>` heading (before the `<div className="space-y-6">`):
+
+```tsx
+      <h2 className="text-2xl font-bold text-white mb-6">
+        Research Results
+      </h2>
+
+      {usage && usage.total_tokens > 0 && (
+        <div className="flex items-center gap-3 mb-4 text-sm text-gray-400">
+          <span>{formatTokenCount(usage.total_tokens)} tokens</span>
+          <span className="text-[#404040]">|</span>
+          <span>{formatCost(usage.estimated_cost_usd)}</span>
+          {usage.model && (
+            <>
+              <span className="text-[#404040]">|</span>
+              <span className="text-gray-500">{usage.model}</span>
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-6">
+```
+
+**Test command:** `cd ui-nextjs && npm run build`
+
+**Commit:** `git commit -m "feat(ui): display per-job token usage and cost on ResultsCard"`
+
+Note: The parent page (`ui-nextjs/app/page.tsx`) threading of the `usage` prop is handled in Task 7.
+
+---
+
+### Task 6: Add cost tracking section to admin page
+
+**Files:**
+- Modify: `ui-nextjs/app/admin/page.tsx`
+
+- [ ] **Step 1: Add cost fetching state and logic**
+
+In `ui-nextjs/app/admin/page.tsx`, add state for cost data and a fetch function. Add these state declarations after the existing state (after `ingestLoading` around line 42):
+
+```typescript
+  // --- Cost tracking state ---
+  interface CostSummaryJob {
+    job_id: string;
+    query: string | null;
+    created_at: string | null;
+    total_tokens: number;
+    estimated_cost_usd: number;
+    model: string | null;
+  }
+
+  interface CostSummary {
+    total_jobs_with_usage: number;
+    total_tokens: number;
+    total_prompt_tokens: number;
+    total_completion_tokens: number;
+    total_estimated_cost_usd: number;
+    avg_tokens_per_job: number;
+    avg_cost_per_job: number;
+    recent_jobs: CostSummaryJob[];
+  }
+
+  const [costSummary, setCostSummary] = useState<CostSummary | null>(null);
+  const [costLoading, setCostLoading] = useState(false);
+```
+
+Add a fetch function after `fetchUsers`:
+
+```typescript
+  const fetchCosts = useCallback(async () => {
+    if (!session?.access_token) return;
+    setCostLoading(true);
+    try {
+      const response = await fetch(`${API_BASE}/api/admin/costs`, {
+        headers: getHeaders(),
+      });
+      if (response.ok) {
+        setCostSummary(await response.json());
+      }
+    } catch {
+      // Silently fail -- cost tracking is informational
+    } finally {
+      setCostLoading(false);
+    }
+  }, [session?.access_token, getHeaders]);
+```
+
+Add the effect to fetch costs when admin (after the `fetchUsers` effect):
+
+```typescript
+  useEffect(() => {
+    if (isAdmin) fetchCosts();
+  }, [isAdmin, fetchCosts]);
+```
+
+- [ ] **Step 2: Add Cost Tracking UI section**
+
+In `ui-nextjs/app/admin/page.tsx`, add a Cost Tracking section in the JSX. Insert it before the "Invite User" form section (before the `{/* Invite form */}` comment):
+
+```tsx
+        {/* Cost Tracking */}
+        <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg p-6 mb-8">
+          <h2 className="text-lg font-semibold text-white mb-4">LLM Cost Tracking</h2>
+          {costLoading && <p className="text-gray-400 text-sm">Loading costs...</p>}
+          {costSummary && (
+            <>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+                <div className="bg-[#292929] rounded-lg p-4 border border-[#404040]">
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Total Spend</p>
+                  <p className="text-xl font-bold text-white mt-1">
+                    {costSummary.total_estimated_cost_usd === 0
+                      ? '$0.00'
+                      : costSummary.total_estimated_cost_usd < 0.01
+                        ? `$${costSummary.total_estimated_cost_usd.toFixed(4)}`
+                        : `$${costSummary.total_estimated_cost_usd.toFixed(2)}`}
+                  </p>
+                </div>
+                <div className="bg-[#292929] rounded-lg p-4 border border-[#404040]">
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Total Tokens</p>
+                  <p className="text-xl font-bold text-white mt-1">
+                    {costSummary.total_tokens >= 1_000_000
+                      ? `${(costSummary.total_tokens / 1_000_000).toFixed(1)}M`
+                      : costSummary.total_tokens >= 1_000
+                        ? `${(costSummary.total_tokens / 1_000).toFixed(1)}k`
+                        : costSummary.total_tokens}
+                  </p>
+                </div>
+                <div className="bg-[#292929] rounded-lg p-4 border border-[#404040]">
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Jobs Tracked</p>
+                  <p className="text-xl font-bold text-white mt-1">
+                    {costSummary.total_jobs_with_usage}
+                  </p>
+                </div>
+                <div className="bg-[#292929] rounded-lg p-4 border border-[#404040]">
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Avg / Job</p>
+                  <p className="text-xl font-bold text-white mt-1">
+                    {costSummary.avg_cost_per_job === 0
+                      ? '$0.00'
+                      : `$${costSummary.avg_cost_per_job.toFixed(4)}`}
+                  </p>
+                </div>
+              </div>
+
+              {costSummary.recent_jobs.length > 0 && (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-[#404040]">
+                        <th className="text-left py-2 px-3 text-gray-400 font-normal">Query</th>
+                        <th className="text-right py-2 px-3 text-gray-400 font-normal">Tokens</th>
+                        <th className="text-right py-2 px-3 text-gray-400 font-normal">Cost</th>
+                        <th className="text-right py-2 px-3 text-gray-400 font-normal">Model</th>
+                        <th className="text-right py-2 px-3 text-gray-400 font-normal">Date</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {costSummary.recent_jobs.map((job) => (
+                        <tr key={job.job_id} className="border-b border-[#404040] last:border-0">
+                          <td className="py-2 px-3 text-gray-300 max-w-xs truncate">
+                            {job.query || '-'}
+                          </td>
+                          <td className="py-2 px-3 text-right text-gray-300 tabular-nums">
+                            {job.total_tokens.toLocaleString()}
+                          </td>
+                          <td className="py-2 px-3 text-right text-gray-300 tabular-nums">
+                            {job.estimated_cost_usd === 0
+                              ? 'free'
+                              : `$${job.estimated_cost_usd.toFixed(4)}`}
+                          </td>
+                          <td className="py-2 px-3 text-right text-gray-500">
+                            {job.model || '-'}
+                          </td>
+                          <td className="py-2 px-3 text-right text-gray-500">
+                            {job.created_at
+                              ? new Date(job.created_at).toLocaleDateString()
+                              : '-'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {costSummary.total_jobs_with_usage === 0 && (
+                <p className="text-gray-500 text-sm">
+                  No cost data yet. Costs will appear after research jobs complete.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+```
+
+**Test command:** `cd ui-nextjs && npm run build`
+
+**Commit:** `git commit -m "feat(ui): add LLM cost tracking section to admin page"`
+
+---
+
+### Task 7: Thread `usage` prop to ResultsCard from the research page
+
+**Files:**
+- Modify: `ui-nextjs/app/page.tsx`
+
+The research page (`ui-nextjs/app/page.tsx`) stores `results` as `ResearchResult | null` (line 22) and sets it from three code paths:
+1. **WebSocket complete** (line 67): `setResults(data.result)` -- WS payload does not carry `usage`.
+2. **Polling** (line 95): `setResults(status.result)` -- `status` is `JobStatus` which has `usage`.
+3. **handleSelectJob** (lines 142/154): from `job.result` or `latestStatus.result` -- both `JobStatus` objects have `usage`.
+
+- [ ] **Step 1: Add `usage` state variable**
+
+In `ui-nextjs/app/page.tsx`, add a state variable for usage. Import `UsageMetrics` from `@/lib/types` (add to the existing import on line 13), then add state after line 22:
+
+```typescript
+import { QueryResponse, ResearchResult, UsageMetrics, WsMessage } from '@/lib/types';
+
+// ... existing state ...
+const [results, setResults] = useState<ResearchResult | null>(null);
+const [usage, setUsage] = useState<UsageMetrics | null>(null);
+```
+
+- [ ] **Step 2: Set usage in WebSocket complete handler**
+
+In the `switch (data.type)` block, update the `'complete'` case (around line 64-69). Capture `jobId` before it is nulled out to fetch usage:
+
+```typescript
+case 'complete':
+  updateLogs(data);
+  setProgress('Research completed!');
+  setResults(data.result);
+  setPhase(null);
+  // Fetch usage from job status (WS complete payload doesn't include it)
+  if (jobId) {
+    getJobStatus(jobId).then(s => setUsage(s.usage ?? null)).catch(() => {});
+  }
+  setJobId(null);
+  break;
+```
+
+- [ ] **Step 3: Set usage in polling path**
+
+In the polling effect (around line 92-96), set usage alongside results:
+
+```typescript
+if (status.status === 'completed') {
+  setProgress('Research completed!');
+  setResults(status.result ?? null);
+  setUsage(status.usage ?? null);
+  setJobId(null);
+  clearInterval(pollInterval);
+}
+```
+
+- [ ] **Step 4: Set usage in handleSelectJob**
+
+In `handleSelectJob` (around line 141-154), set usage in both completion paths:
+
+```typescript
+// Path 1: job already completed (line 141-142)
+if (job.status === 'completed' && job.result) {
+  setResults(job.result);
+  setUsage(job.usage ?? null);
+  // ...existing scroll code...
+}
+
+// Path 2: fetched latest status (line 153-154)
+if (latestStatus.status === 'completed' && latestStatus.result) {
+  setResults(latestStatus.result);
+  setUsage(latestStatus.usage ?? null);
+}
+```
+
+- [ ] **Step 5: Clear usage on new job submission**
+
+In `handleSubmit` (line 117), clear usage when starting a new job:
+
+```typescript
+setResults(null);
+setUsage(null);
+```
+
+- [ ] **Step 6: Pass usage to ResultsCard**
+
+Update line 269 from:
+
+```tsx
+<ResultsCard results={results} />
+```
+
+to:
+
+```tsx
+<ResultsCard results={results} usage={usage} />
+```
+
+**Test command:** `cd ui-nextjs && npm run build && npm run lint`
+
+**Commit:** `git commit -m "feat(ui): thread usage prop to ResultsCard from research page"`
+
+---
+
+### Task 8: Run full test suite and build verification
+
+- [ ] **Step 1: Run backend tests**
+
+```bash
+python -m pytest tests/test_database.py tests/test_cost_tracker.py tests/test_app_schemas.py tests/test_admin_costs.py -v
+```
+
+- [ ] **Step 2: Run full backend test suite**
+
+```bash
+python -m pytest tests/ -v --timeout=30
+```
+
+- [ ] **Step 3: Run frontend build and lint**
+
+```bash
+cd ui-nextjs && npm run build && npm run lint
+```
+
+- [ ] **Step 4: Apply migration to local database**
+
+```bash
+python scripts/run_vector_migration.py
+# Or manually:
+# psql -h localhost -p 54322 -U postgres -d postgres -f supabase/migrations/20260407000001_add_usage_column.sql
+```
+
+**Commit:** (no commit -- verification step)

--- a/docs/superpowers/plans/2026-04-07-experiment-tracker.md
+++ b/docs/superpowers/plans/2026-04-07-experiment-tracker.md
@@ -1,0 +1,793 @@
+# Experiment Tracker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an "Experiments" tab to the /learn page showing the fine-tuning experiment timeline, metrics comparison, and cumulative training costs. All data is static (parsed at build time from `docs/training-experiment-log.md`).
+
+**Architecture:** A new `experiments` tab added to the existing `LearnTabs` component on `/learn`. Three new client components (`ExperimentTimeline`, `ExperimentMetrics`, `TrainingCostTracker`) consume static TypeScript data from `ui-nextjs/lib/experiments.ts`. No API endpoints or backend changes needed.
+
+**Tech Stack:** Next.js (App Router), React 19, TypeScript, Tailwind CSS 4, Recharts (already installed)
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `ui-nextjs/lib/experiments.ts` | Static experiment data as typed constants |
+| Create | `ui-nextjs/components/learn/ExperimentTimeline.tsx` | Timeline of experiment cards with status badges |
+| Create | `ui-nextjs/components/learn/ExperimentMetrics.tsx` | Per-experiment metrics comparison table |
+| Create | `ui-nextjs/components/learn/TrainingCostTracker.tsx` | Cumulative cost bar chart via Recharts |
+| Modify | `ui-nextjs/app/learn/page.tsx` | Add "Experiments" tab to LearnTabs |
+
+---
+
+### Task 1: Static Experiment Data
+
+**Files:**
+- Create: `ui-nextjs/lib/experiments.ts`
+
+- [ ] **Step 1: Create the experiments data module**
+
+```typescript
+// ui-nextjs/lib/experiments.ts
+
+export type ExperimentStatus = 'pass' | 'fail' | 'partial';
+
+export interface ExperimentMetrics {
+  /** Parser entity extraction F1 score (0-100) */
+  entity_f1?: number;
+  /** Parser JSON valid rate (0-100) */
+  json_valid_rate?: number;
+  /** Integration tests passing (e.g. "11/11") */
+  integration_tests?: string;
+  /** Evaluator hallucination detection accuracy (0-100) */
+  hallucination_accuracy?: number;
+  /** Evaluator relevance MAE (lower is better) */
+  relevance_mae?: number;
+  /** Data source accuracy (0-100) */
+  data_source_accuracy?: number;
+}
+
+export interface Experiment {
+  id: number;
+  date: string;
+  name: string;
+  baseModel: string;
+  hypothesis: string;
+  keyResult: string;
+  status: ExperimentStatus;
+  metrics: ExperimentMetrics;
+  cost: {
+    claudeApi: number;
+    colabCompute: number;
+    total: number;
+  };
+  cumulativeCost: number;
+  lessons: string[];
+}
+
+export const EXPERIMENTS: Experiment[] = [
+  {
+    id: 1,
+    date: '2026-03-23',
+    name: 'Sprint 2 baseline',
+    baseModel: 'Qwen2.5-3B',
+    hypothesis:
+      'Initial fine-tuning on ~115 examples per task would produce usable JSON outputs.',
+    keyResult: '3/11 integration tests passing',
+    status: 'fail',
+    metrics: {
+      integration_tests: '3/11',
+      json_valid_rate: 30,
+    },
+    cost: { claudeApi: 15, colabCompute: 4, total: 19 },
+    cumulativeCost: 19,
+    lessons: [
+      'Insufficient training data (~115 examples) causes narrative output instead of JSON',
+      'Incorrect chat template tokenization loses structure',
+    ],
+  },
+  {
+    id: 2,
+    date: '2026-03-25',
+    name: 'Sprint 2.5 JSON fix',
+    baseModel: 'Qwen2.5-3B',
+    hypothesis:
+      'Increasing data to 1,000 pairs, 7 epochs, proper chat templates, and Modelfile fixes would resolve JSON output failures.',
+    keyResult: '11/11 integration tests passing',
+    status: 'pass',
+    metrics: {
+      integration_tests: '11/11',
+      json_valid_rate: 95,
+    },
+    cost: { claudeApi: 15, colabCompute: 4, total: 19 },
+    cumulativeCost: 38,
+    lessons: [
+      'Training data volume and chat template formatting were the primary drivers',
+      'Ollama double-wraps ChatML templates — needs explicit TEMPLATE directive',
+      'Use tokenizer.apply_chat_template() instead of manual formatting',
+    ],
+  },
+  {
+    id: 3,
+    date: '2026-03-29',
+    name: 'v2 Qwen 3.5 upgrade',
+    baseModel: 'Qwen3.5-4B',
+    hypothesis:
+      'Upgrading to Qwen3.5-4B (Gated Delta Networks) would improve multi-task evaluation capacity without significant cost increase.',
+    keyResult: 'Base model upgrade, evaluator 0% (prompt mismatch)',
+    status: 'partial',
+    metrics: {
+      entity_f1: 56.83,
+      data_source_accuracy: 71.6,
+      hallucination_accuracy: 0,
+    },
+    cost: { claudeApi: 0.02, colabCompute: 4, total: 4.02 },
+    cumulativeCost: 42.02,
+    lessons: [
+      'Evaluator 0% was a system prompt mismatch, not model failure',
+      'Inference prompt must match the training prompt exactly for multi-task models',
+    ],
+  },
+  {
+    id: 4,
+    date: '2026-03-31',
+    name: 'v3 document layer + subtask dispatch',
+    baseModel: 'Qwen3.5-4B',
+    hypothesis:
+      'Adding document passages to training data and matching inference prompts to subtask-specific training prompts would improve parser F1 and evaluator accuracy.',
+    keyResult: 'Parser entity F1 +16pp, evaluator 0% -> 84%',
+    status: 'pass',
+    metrics: {
+      entity_f1: 72.66,
+      data_source_accuracy: 98.77,
+      json_valid_rate: 98.77,
+      hallucination_accuracy: 84,
+      relevance_mae: 1.53,
+    },
+    cost: { claudeApi: 0.59, colabCompute: 4, total: 4.59 },
+    cumulativeCost: 46.61,
+    lessons: [
+      'Document layer passages taught the model document-style text patterns',
+      'Community framing pairs drove parser entity_f1 from 56.83% to 72.66%',
+      'Subtask dispatch was the dominant factor for evaluator improvement',
+      'Inference prompt must match training prompt exactly for small multi-task models',
+    ],
+  },
+  {
+    id: 5,
+    date: '2026-04-01',
+    name: 'v3.1 expanded state coverage',
+    baseModel: 'Qwen3.5-4B',
+    hypothesis:
+      'Training evaluator on documents from 8 states instead of 4 would push hallucination accuracy past the 85% ship threshold.',
+    keyResult: 'FAILED: Domain re-adaptation broke evaluator output format',
+    status: 'fail',
+    metrics: {
+      hallucination_accuracy: 0.5,
+      relevance_mae: 4.0,
+    },
+    cost: { claudeApi: 0.59, colabCompute: 4, total: 4.59 },
+    cumulativeCost: 51.2,
+    lessons: [
+      'Never re-run domain adaptation without retraining ALL task adapters',
+      'Preserve domain_merged checkpoint before any re-training run',
+      'Evaluator is the most fragile adapter (r=16, attention-only, multiple schemas)',
+      'For incremental data additions, retrain only the task adapter without re-running domain adaptation',
+    ],
+  },
+  {
+    id: 6,
+    date: '2026-04-03',
+    name: 'v3.0 full retrain (clean slate)',
+    baseModel: 'Qwen3.5-4B',
+    hypothesis:
+      'Retraining ALL phases from a clean state on the expanded corpus would produce co-adapted adapters, unlike v3.1 which only retrained the evaluator.',
+    keyResult: 'Hallucination 87% (ship!), parser entity F1 75%',
+    status: 'partial',
+    metrics: {
+      entity_f1: 74.88,
+      json_valid_rate: 96.3,
+      hallucination_accuracy: 87.11,
+      relevance_mae: 2.7,
+    },
+    cost: { claudeApi: 0, colabCompute: 4, total: 4 },
+    cumulativeCost: 55.2,
+    lessons: [
+      'Always verify the editable install target after switching branches/worktrees',
+      'Explicit API options > Modelfile parameters for custom GGUFs',
+      'Qwen 3.5 thinking mode cannot be disabled for custom GGUF files',
+      'Register ALL models the eval harness needs before running evals',
+    ],
+  },
+];
+
+/** Metrics that should be displayed as percentages (value is 0-100). */
+export const PERCENT_METRICS = new Set([
+  'entity_f1',
+  'json_valid_rate',
+  'hallucination_accuracy',
+  'data_source_accuracy',
+]);
+
+/** Metrics where lower is better. */
+export const LOWER_IS_BETTER = new Set(['relevance_mae']);
+
+/** Human-readable labels for metric keys. */
+export const METRIC_LABELS: Record<string, string> = {
+  entity_f1: 'Parser Entity F1',
+  json_valid_rate: 'JSON Valid Rate',
+  integration_tests: 'Integration Tests',
+  hallucination_accuracy: 'Hallucination Detection',
+  relevance_mae: 'Relevance MAE',
+  data_source_accuracy: 'Data Source Accuracy',
+};
+
+/** Ship thresholds for key metrics. */
+export const SHIP_THRESHOLDS: Record<string, { value: number; direction: 'gte' | 'lte' }> = {
+  entity_f1: { value: 80, direction: 'gte' },
+  hallucination_accuracy: { value: 85, direction: 'gte' },
+  relevance_mae: { value: 0.8, direction: 'lte' },
+  json_valid_rate: { value: 95, direction: 'gte' },
+};
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd ui-nextjs && npx tsc --noEmit lib/experiments.ts
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui-nextjs/lib/experiments.ts
+git commit -m "feat(learn): add static experiment data for training tracker (#176)"
+```
+
+---
+
+### Task 2: ExperimentTimeline Component
+
+**Files:**
+- Create: `ui-nextjs/components/learn/ExperimentTimeline.tsx`
+
+- [ ] **Step 1: Create the timeline component**
+
+This component renders each experiment as a card in a vertical timeline. Cards show date, name, base model, key result, and a pass/fail/partial badge. The design matches the existing dark theme used in `ConceptSection`, `TutorialStep`, and `EvalMetricsPanel`.
+
+```tsx
+// ui-nextjs/components/learn/ExperimentTimeline.tsx
+'use client';
+
+import { EXPERIMENTS, type Experiment, type ExperimentStatus } from '@/lib/experiments';
+
+const STATUS_CONFIG: Record<ExperimentStatus, { bg: string; text: string; label: string; border: string }> = {
+  pass: { bg: 'bg-[#1f3524]', text: 'text-[#4ade80]', label: 'Pass', border: 'border-[#00ff32]/30' },
+  fail: { bg: 'bg-[#402424]', text: 'text-[#f87171]', label: 'Failed', border: 'border-red-400/30' },
+  partial: { bg: 'bg-[#3d3520]', text: 'text-[#fbbf24]', label: 'Partial', border: 'border-yellow-400/30' },
+};
+
+function ExperimentCard({ experiment }: { experiment: Experiment }) {
+  const status = STATUS_CONFIG[experiment.status];
+
+  return (
+    <div className="relative pl-8 pb-8 last:pb-0">
+      {/* Timeline connector line */}
+      <div className="absolute left-[11px] top-6 bottom-0 w-px bg-[#404040] last:hidden" />
+
+      {/* Timeline dot */}
+      <div
+        className={`absolute left-0 top-1.5 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${status.bg} ${status.text} ring-2 ring-[#1a1a1a]`}
+      >
+        {experiment.id}
+      </div>
+
+      {/* Card */}
+      <div className={`bg-[#292929] border ${status.border} rounded-lg p-5`}>
+        {/* Header row */}
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <div>
+            <h4 className="text-white font-semibold text-sm">{experiment.name}</h4>
+            <div className="flex items-center gap-3 mt-1">
+              <span className="text-xs text-gray-500">{experiment.date}</span>
+              <span className="text-xs text-gray-500">{experiment.baseModel}</span>
+            </div>
+          </div>
+          <span
+            className={`flex-shrink-0 ${status.bg} ${status.text} px-2.5 py-0.5 rounded text-[11px] font-semibold uppercase tracking-wide`}
+          >
+            {status.label}
+          </span>
+        </div>
+
+        {/* Key result */}
+        <p className="text-gray-300 text-sm mb-3">{experiment.keyResult}</p>
+
+        {/* Hypothesis (collapsed style) */}
+        <p className="text-gray-500 text-xs italic">{experiment.hypothesis}</p>
+
+        {/* Cost badge */}
+        <div className="mt-3 flex items-center gap-2">
+          <span className="text-[10px] text-gray-500 uppercase tracking-wider">Cost</span>
+          <span className="text-xs text-gray-400 font-mono">
+            ${experiment.cost.total.toFixed(2)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ExperimentTimeline() {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-white mb-2">Training Timeline</h3>
+      <p className="text-sm text-gray-400 mb-6">
+        Six experiments over two weeks, from baseline failure to shipping hallucination detection.
+      </p>
+      <div className="max-w-3xl">
+        {EXPERIMENTS.map((exp) => (
+          <ExperimentCard key={exp.id} experiment={exp} />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd ui-nextjs && npx tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui-nextjs/components/learn/ExperimentTimeline.tsx
+git commit -m "feat(learn): add ExperimentTimeline component (#176)"
+```
+
+---
+
+### Task 3: ExperimentMetrics Component
+
+**Files:**
+- Create: `ui-nextjs/components/learn/ExperimentMetrics.tsx`
+
+- [ ] **Step 1: Create the metrics comparison component**
+
+This component shows a table comparing key metrics across all experiments, following the `MetricRow` pattern from `EvalMetricsPanel`. Metrics that meet the ship threshold get a green highlight; those that regressed get red.
+
+```tsx
+// ui-nextjs/components/learn/ExperimentMetrics.tsx
+'use client';
+
+import {
+  EXPERIMENTS,
+  METRIC_LABELS,
+  PERCENT_METRICS,
+  LOWER_IS_BETTER,
+  SHIP_THRESHOLDS,
+} from '@/lib/experiments';
+
+/** All metric keys that appear in at least one experiment. */
+const METRIC_KEYS = [
+  'integration_tests',
+  'json_valid_rate',
+  'entity_f1',
+  'data_source_accuracy',
+  'hallucination_accuracy',
+  'relevance_mae',
+] as const;
+
+type MetricKey = (typeof METRIC_KEYS)[number];
+
+function formatValue(key: MetricKey, value: string | number | undefined): string {
+  if (value === undefined) return '-';
+  if (typeof value === 'string') return value;
+  if (PERCENT_METRICS.has(key)) return `${value.toFixed(1)}%`;
+  return value.toFixed(2);
+}
+
+function meetsThreshold(key: MetricKey, value: string | number | undefined): boolean | null {
+  if (value === undefined || typeof value === 'string') return null;
+  const threshold = SHIP_THRESHOLDS[key];
+  if (!threshold) return null;
+  return threshold.direction === 'gte' ? value >= threshold.value : value <= threshold.value;
+}
+
+function cellColor(key: MetricKey, value: string | number | undefined): string {
+  const meets = meetsThreshold(key, value);
+  if (meets === true) return 'text-[#4ade80]';
+  if (meets === false && value !== undefined) return 'text-gray-300';
+  return 'text-gray-500';
+}
+
+export default function ExperimentMetrics() {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-white mb-2">Metrics Comparison</h3>
+      <p className="text-sm text-gray-400 mb-6">
+        Key metrics across all training experiments. Green values meet ship thresholds.
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[#404040]">
+              <th className="text-left text-gray-400 text-xs font-medium uppercase tracking-wider py-3 pr-4 sticky left-0 bg-[#1a1a1a]">
+                Metric
+              </th>
+              {EXPERIMENTS.map((exp) => (
+                <th
+                  key={exp.id}
+                  className="text-center text-gray-400 text-xs font-medium uppercase tracking-wider py-3 px-3 min-w-[80px]"
+                >
+                  <div>Exp {exp.id}</div>
+                  <div className="text-[10px] text-gray-600 font-normal normal-case">
+                    {exp.date.slice(5)}
+                  </div>
+                </th>
+              ))}
+              <th className="text-center text-[#00ff32] text-xs font-medium uppercase tracking-wider py-3 px-3">
+                Target
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[#333]">
+            {METRIC_KEYS.map((key) => {
+              const threshold = SHIP_THRESHOLDS[key];
+              const isLower = LOWER_IS_BETTER.has(key);
+              return (
+                <tr key={key}>
+                  <td className="text-gray-300 text-xs py-2.5 pr-4 sticky left-0 bg-[#1a1a1a]">
+                    {METRIC_LABELS[key] ?? key}
+                    {isLower && (
+                      <span className="text-gray-600 ml-1 text-[10px]">(lower is better)</span>
+                    )}
+                  </td>
+                  {EXPERIMENTS.map((exp) => {
+                    const value = exp.metrics[key as keyof typeof exp.metrics];
+                    return (
+                      <td
+                        key={exp.id}
+                        className={`text-center font-mono text-xs py-2.5 px-3 ${cellColor(key, value)}`}
+                      >
+                        {formatValue(key, value)}
+                      </td>
+                    );
+                  })}
+                  <td className="text-center text-xs py-2.5 px-3 text-[#00ff32]/70 font-mono">
+                    {threshold
+                      ? `${threshold.direction === 'gte' ? '>=' : '<='} ${
+                          PERCENT_METRICS.has(key)
+                            ? `${threshold.value}%`
+                            : threshold.value.toFixed(2)
+                        }`
+                      : '-'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd ui-nextjs && npx tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui-nextjs/components/learn/ExperimentMetrics.tsx
+git commit -m "feat(learn): add ExperimentMetrics comparison table (#176)"
+```
+
+---
+
+### Task 4: TrainingCostTracker Component
+
+**Files:**
+- Create: `ui-nextjs/components/learn/TrainingCostTracker.tsx`
+
+- [ ] **Step 1: Create the cost tracker component**
+
+Uses Recharts (already in `package.json`) to render a bar chart of per-experiment costs with a cumulative line overlay. Follows the dark theme styling.
+
+```tsx
+// ui-nextjs/components/learn/TrainingCostTracker.tsx
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Line,
+  ComposedChart,
+  Legend,
+} from 'recharts';
+import { EXPERIMENTS } from '@/lib/experiments';
+
+const chartData = EXPERIMENTS.map((exp) => ({
+  name: `Exp ${exp.id}`,
+  label: exp.name,
+  cost: exp.cost.total,
+  cumulative: exp.cumulativeCost,
+  status: exp.status,
+}));
+
+const TOTAL_COST = EXPERIMENTS[EXPERIMENTS.length - 1].cumulativeCost;
+
+function CustomTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: (typeof chartData)[number]; value: number; dataKey: string }>;
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0].payload;
+  return (
+    <div className="bg-[#292929] border border-[#404040] rounded-lg p-3 text-sm shadow-lg">
+      <p className="text-white font-semibold mb-1">{data.label}</p>
+      <p className="text-gray-400">
+        Cost: <span className="text-gray-200 font-mono">${data.cost.toFixed(2)}</span>
+      </p>
+      <p className="text-gray-400">
+        Cumulative: <span className="text-[#00ff32] font-mono">${data.cumulative.toFixed(2)}</span>
+      </p>
+    </div>
+  );
+}
+
+export default function TrainingCostTracker() {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-2">
+        <h3 className="text-lg font-semibold text-white">Training Costs</h3>
+        <span className="text-sm text-gray-400">
+          Total: <span className="text-[#00ff32] font-mono">${TOTAL_COST.toFixed(2)}</span>
+        </span>
+      </div>
+      <p className="text-sm text-gray-400 mb-6">
+        Cumulative cost across six experiments. Initial experiments dominated by training data
+        generation via Claude API; later experiments reused existing data.
+      </p>
+
+      <div className="bg-[#292929] border border-[#404040] rounded-lg p-4">
+        <ResponsiveContainer width="100%" height={300}>
+          <ComposedChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+            <XAxis
+              dataKey="name"
+              tick={{ fill: '#9ca3af', fontSize: 12 }}
+              axisLine={{ stroke: '#404040' }}
+              tickLine={{ stroke: '#404040' }}
+            />
+            <YAxis
+              yAxisId="cost"
+              tick={{ fill: '#9ca3af', fontSize: 12 }}
+              axisLine={{ stroke: '#404040' }}
+              tickLine={{ stroke: '#404040' }}
+              tickFormatter={(v: number) => `$${v}`}
+            />
+            <YAxis
+              yAxisId="cumulative"
+              orientation="right"
+              tick={{ fill: '#9ca3af', fontSize: 12 }}
+              axisLine={{ stroke: '#404040' }}
+              tickLine={{ stroke: '#404040' }}
+              tickFormatter={(v: number) => `$${v}`}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              wrapperStyle={{ color: '#9ca3af', fontSize: 12, paddingTop: 8 }}
+            />
+            <Bar
+              yAxisId="cost"
+              dataKey="cost"
+              name="Per-experiment cost"
+              fill="#404040"
+              radius={[4, 4, 0, 0]}
+            />
+            <Line
+              yAxisId="cumulative"
+              dataKey="cumulative"
+              name="Cumulative total"
+              stroke="#00ff32"
+              strokeWidth={2}
+              dot={{ fill: '#00ff32', r: 4 }}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Cost breakdown */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-4">
+        <div className="bg-[#292929] border border-[#404040] rounded-lg p-4 text-center">
+          <div className="text-2xl font-bold text-white font-mono">
+            ${TOTAL_COST.toFixed(2)}
+          </div>
+          <div className="text-xs text-gray-500 mt-1 uppercase tracking-wider">Total Cost</div>
+        </div>
+        <div className="bg-[#292929] border border-[#404040] rounded-lg p-4 text-center">
+          <div className="text-2xl font-bold text-white font-mono">{EXPERIMENTS.length}</div>
+          <div className="text-xs text-gray-500 mt-1 uppercase tracking-wider">Experiments</div>
+        </div>
+        <div className="bg-[#292929] border border-[#404040] rounded-lg p-4 text-center">
+          <div className="text-2xl font-bold text-white font-mono">
+            ${(TOTAL_COST / EXPERIMENTS.length).toFixed(2)}
+          </div>
+          <div className="text-xs text-gray-500 mt-1 uppercase tracking-wider">Avg / Experiment</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd ui-nextjs && npx tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui-nextjs/components/learn/TrainingCostTracker.tsx
+git commit -m "feat(learn): add TrainingCostTracker chart component (#176)"
+```
+
+---
+
+### Task 5: Wire Experiments Tab into Learn Page
+
+**Files:**
+- Modify: `ui-nextjs/app/learn/page.tsx`
+
+- [ ] **Step 1: Add imports for the new components**
+
+At the top of `ui-nextjs/app/learn/page.tsx`, add the three new imports after the existing imports (line 10):
+
+```typescript
+// Add after line 10 (after `import BuildTab from '@/components/learn/BuildTab';`)
+import ExperimentTimeline from '@/components/learn/ExperimentTimeline';
+import ExperimentMetrics from '@/components/learn/ExperimentMetrics';
+import TrainingCostTracker from '@/components/learn/TrainingCostTracker';
+```
+
+- [ ] **Step 2: Add the Experiments tab to LearnTabs**
+
+In the `tabs` array prop of `<LearnTabs>`, add a new tab entry after the `build` tab (after line 190):
+
+```typescript
+            {
+              id: 'experiments',
+              label: 'Experiments',
+              content: (
+                <div className="space-y-12">
+                  <ExperimentTimeline />
+                  <ExperimentMetrics />
+                  <TrainingCostTracker />
+                </div>
+              ),
+            },
+```
+
+The full modified `tabs` prop should be (showing only the new entry in context):
+
+```typescript
+        <LearnTabs
+          tabs={[
+            {
+              id: 'compare',
+              label: 'Compare',
+              content: ( /* ... existing ... */ ),
+            },
+            {
+              id: 'learn',
+              label: 'Learn',
+              content: ( /* ... existing ... */ ),
+            },
+            {
+              id: 'build',
+              label: 'Build',
+              content: <BuildTab />,
+            },
+            {
+              id: 'experiments',
+              label: 'Experiments',
+              content: (
+                <div className="space-y-12">
+                  <ExperimentTimeline />
+                  <ExperimentMetrics />
+                  <TrainingCostTracker />
+                </div>
+              ),
+            },
+          ]}
+        />
+```
+
+- [ ] **Step 3: Verify build passes**
+
+Run:
+```bash
+cd ui-nextjs && npm run build
+```
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Verify lint passes**
+
+Run:
+```bash
+cd ui-nextjs && npm run lint
+```
+Expected: No lint errors.
+
+- [ ] **Step 5: Manual verification**
+
+Run `cd ui-nextjs && npm run dev` and navigate to `http://localhost:3000/learn#experiments`. Verify:
+1. The "Experiments" tab appears in the tab bar alongside Compare, Learn, Build
+2. Clicking it shows the ExperimentTimeline with 6 experiment cards
+3. Each card shows date, name, base model, key result, and a colored status badge
+4. The ExperimentMetrics table shows all 6 experiments with metric values
+5. Green values indicate metrics meeting ship thresholds
+6. The TrainingCostTracker shows a bar chart with cumulative line
+7. Total cost displays as $55.20
+8. Direct navigation via `#experiments` hash works
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui-nextjs/app/learn/page.tsx
+git commit -m "feat(learn): add Experiments tab with timeline, metrics, and costs (#176)"
+```
+
+---
+
+### Task 6: Final Verification
+
+- [ ] **Step 1: Full build from clean state**
+
+Run:
+```bash
+cd ui-nextjs && rm -rf .next && npm run build
+```
+Expected: Production build succeeds.
+
+- [ ] **Step 2: Verify all new files exist**
+
+```bash
+ls -la ui-nextjs/lib/experiments.ts
+ls -la ui-nextjs/components/learn/ExperimentTimeline.tsx
+ls -la ui-nextjs/components/learn/ExperimentMetrics.tsx
+ls -la ui-nextjs/components/learn/TrainingCostTracker.tsx
+```
+
+- [ ] **Step 3: Verify tab hash navigation**
+
+Open `http://localhost:3000/learn#experiments` in browser. The Experiments tab should be active on page load.

--- a/docs/superpowers/specs/2026-04-06-searxng-warmup-design.md
+++ b/docs/superpowers/specs/2026-04-06-searxng-warmup-design.md
@@ -1,0 +1,85 @@
+# SearXNG Pre-Warm on Job Start — Design Spec
+
+**Issue:** #173
+**Date:** 2026-04-06
+
+## Problem
+
+SearXNG on Fly.io auto-stops when idle. The first research job after idle gets empty search results because the machine takes 3-10s to wake up. The agent's search tool times out or returns errors, and the agent falls back to LLM-only knowledge — producing reports without web sources.
+
+Impact: `source_urls: []`, hallucination eval score drops, report quality degrades.
+
+## Solution
+
+Inline warmup in `run_research_job` with phase-aware progress messages.
+
+## Design
+
+### Phase System
+
+All progress WebSocket messages include a `phase` field so the frontend can track the current job stage:
+
+```
+warmup → init → research → evaluation → complete
+```
+
+### Backend: `research_runner.py`
+
+1. Add optional `phase` parameter to `notify_progress`.
+2. After the OpenTelemetry span starts, send `notify_progress("Warming up search services...", phase="warmup")`.
+3. Use `httpx.AsyncClient` to `GET {SEARXNG_BASE_URL}/healthz` with a 15s timeout.
+4. If it succeeds or fails, log the result and proceed — no retry.
+5. Continue with `notify_progress("Initializing research crew...", phase="init")`.
+6. Tag all subsequent progress messages with their phase: `init`, `research`, `evaluation`.
+
+Access `SEARXNG_BASE_URL` from settings. If empty or search provider isn't SearXNG, skip warmup entirely.
+
+The ping is `await`ed (not fire-and-forget) so it completes before crew kickoff.
+
+### Frontend: `types.ts`
+
+Add `phase?: string` to `WsProgressMessage`. Optional for backwards compatibility.
+
+### Frontend: `page.tsx`
+
+- New state: `const [phase, setPhase] = useState<string | null>(null)`
+- In the `'progress'` WebSocket case, extract `data.phase` and call `setPhase()`
+- Pass `phase` to `ProgressCard`
+- Reset `phase` to `null` on job complete/error
+
+### Frontend: `ProgressCard.tsx`
+
+Accept new `phase` prop. Three visual states for the connection indicator:
+
+| State | Dot color | Label |
+|-------|-----------|-------|
+| `phase === "warmup"` | Amber pulsing (`bg-amber-500 animate-pulse`) | "Warming up..." |
+| `isConnected` | Green (`bg-[#00ff32]`) | "Connected" |
+| disconnected | Red (`bg-red-500`) | "Disconnected" |
+
+Progress bar: amber pulse during warmup, green pulse otherwise. Transitions automatically when phase advances past `"warmup"`.
+
+Matches existing design system: dark theme (`#333333` cards), neon green (`#00ff32`) accent, `animate-pulse` pattern.
+
+## Error Handling
+
+- **Warmup failure:** Log warning, proceed. Agents already handle search failures gracefully.
+- **SearXNG not configured:** Skip warmup if `SEARXNG_BASE_URL` is empty or search provider isn't SearXNG.
+- **WebSocket not connected:** Fallback polling doesn't surface `phase` — acceptable since warmup is a brief transient state and polling is the degraded path.
+
+## Files to Change
+
+- `src/d4bl/services/research_runner.py` — warmup ping + phase on all progress messages
+- `ui-nextjs/lib/types.ts` — add `phase?` to `WsProgressMessage`
+- `ui-nextjs/app/page.tsx` — track phase state, pass to ProgressCard
+- `ui-nextjs/components/ProgressCard.tsx` — amber warmup visual state
+
+## Test Plan
+
+- [ ] Job start sends "Warming up search services..." progress message with `phase: "warmup"`
+- [ ] SearXNG `/healthz` is pinged before crew kickoff
+- [ ] ProgressCard shows amber warmup state during warmup phase
+- [ ] After warmup, transitions to normal green progress state
+- [ ] All progress messages include a `phase` field
+- [ ] If SearXNG is down, job still completes (graceful degradation)
+- [ ] If SearXNG is not configured, warmup is skipped

--- a/docs/training-experiment-log.md
+++ b/docs/training-experiment-log.md
@@ -15,6 +15,7 @@
 | 3 | 2026-03-29 | v2 Qwen 3.5 upgrade | Qwen3.5-4B | Base model upgrade, v2 training data |
 | 4 | 2026-03-31 | v3 document layer + subtask dispatch | Qwen3.5-4B | Parser entity F1 +16pp, evaluator 0%->84% |
 | 5 | 2026-04-01 | v3.1 expanded state coverage (FAILED) | Qwen3.5-4B | Domain re-adaptation broke evaluator output format |
+| 6 | 2026-04-03 | v3.0 full retrain (clean slate) | Qwen3.5-4B | Hallucination 87%, parser entity F1 75%, all adapters co-adapted |
 
 ## Cumulative Cost
 
@@ -24,7 +25,8 @@
 | 2. Sprint 2.5 JSON fix | ~$15.00 | ~$4.00 | ~$38.00 |
 | 3. v2 Qwen 3.5 upgrade | $0.02 (resume) | ~$4.00 | ~$42.02 |
 | 4. v3 document layer | $0.59 | ~$4.00 | ~$46.61 |
-| 5. v3.1 expanded states (FAILED) | $0.59 | ~$4.00 | **~$51.20** |
+| 5. v3.1 expanded states (FAILED) | $0.59 | ~$4.00 | ~$51.20 |
+| 6. v3.0 full retrain | $0.00 | ~$4.00 | **~$55.20** |
 
 ---
 
@@ -305,6 +307,96 @@ Reverted to the v3 evaluator GGUF (March 31 training run) which produces correct
 | Doc hallucination pair generation (175 Claude calls) | $0.59 |
 | Colab A100 training (~48 min) | ~$4.00 |
 | **Total (wasted)** | **~$4.59** |
+
+---
+
+## Experiment 6: v3.0 Full Retrain (Clean Slate)
+
+**Date:** 2026-04-03
+**Status:** Partial ship — hallucination passes, parser/relevance need work
+
+### Observation
+
+The v3.1 attempt (Experiment 5) overwrote the `domain_merged` checkpoint. All task adapters were invalidated since they were LoRA deltas trained against the v3 domain base. A full retrain from scratch was needed.
+
+### Hypothesis
+
+Retraining ALL phases (domain adaptation + 3 task adapters) on the expanded corpus (44,235 passages) from a clean state would produce co-adapted adapters that work correctly together, unlike v3.1 which only retrained the evaluator.
+
+### Methodology
+
+1. Cleared ALL stale training state from Drive (kept only `training_data_final/`)
+2. Full training on Colab A100: domain → parser → explainer → evaluator → GGUF export
+3. Used `--force` flag to ignore any cached checkpoints
+4. Backed up `domain_merged` to versioned Drive directory (`d4bl_training_v3_domain_merged_backup/`)
+5. Registered all 7 Ollama models (3 main + 4 evaluator subtasks)
+
+#### Training health (all 4/4 phases passed)
+
+| Phase | Train Loss | Eval Loss | Overfit Ratio | Duration |
+|-------|-----------|-----------|---------------|----------|
+| Domain Adaptation | 0.481 | — | — | 59m 42s |
+| Query Parser | 0.323 | 0.320 | 0.99 | 8m 37s |
+| Data Explainer | 0.679 | 0.753 | 1.11 | 7m 40s |
+| Evaluator | 0.549 | 0.603 | 1.10 | 30m 43s |
+
+Total training time: 2h 02m. GGUF exports: 3 × 2.52 GB (Q4_K_M).
+
+### Results
+
+| Metric | v3 (Exp 4) | v3.1 (Exp 5, broken) | v3.0 retrain (this) | Ship threshold |
+|--------|-----------|---------------------|---------------------|----------------|
+| hallucination_accuracy | 84% | 0.5% | **87.11%** | ≥ 85% ✓ |
+| relevance_mae | 1.53 | 4.00 | 2.70 | ≤ 0.80 ✗ |
+| entity_f1 | 91% | — | 74.88% | ≥ 80% ✗ |
+| json_valid (parser) | 98% | — | 96.30% | — |
+| json_valid (explainer) | 100% | — | 100% | — |
+| p95 latency (parser) | — | — | 5170ms | ≤ 1000ms ✗ |
+| p95 latency (explainer) | — | — | 13751ms | ≤ 3000ms ✗ |
+
+### Analysis
+
+**Hallucination accuracy (87.11%)** crosses the 85% ship threshold for the first time. This is a genuine improvement over v3's 84%, likely from the expanded corpus providing more diverse factual grounding patterns.
+
+**Entity F1 (74.88%)** regressed from v3's 91%. Possible causes:
+- The expanded domain corpus shifted the base model's entity recognition behavior
+- All adapters were retrained from scratch — the parser lost some of v3's co-adaptation
+- Needs investigation: compare predicted vs expected entities to identify specific failure modes
+
+**Relevance MAE (2.70)** is worse than v3's 1.53. The eval harness now correctly dispatches to subtask-specific models (d4bl-evaluator-relevance), which may use a different scoring scale than expected. Scoring calibration mismatch under investigation.
+
+**Latency** is dominated by Qwen 3.5's `<think>` reasoning blocks (empty, ~10 tokens overhead) plus the natural generation speed of a 4B model on Mac hardware (~60 tok/s). The `<think>` blocks cannot be disabled for custom GGUF files — tested: Ollama API `think: false`, Modelfile `PARAMETER think false`, and `/no_think` system prompt token. None work. Latency thresholds need adjustment for local inference or require cloud GPU deployment.
+
+### Infrastructure fixes discovered during eval
+
+1. **Stale editable install**: `pip install -e .` pointed to a different directory (`d4bl-fix-169`). All code changes to `ollama_client.py` and `validation/model_output.py` were invisible. Fixed by re-running `pip install -e .` in the correct repo.
+2. **`ollama_generate` missing `num_predict`**: The Ollama API client only sent `temperature` in options. Added `num_predict: 2048` to prevent JSON truncation.
+3. **Modelfile `num_predict` not honored**: `ollama create` doesn't reliably apply Modelfile parameters to custom GGUFs. Workaround: send `num_predict` explicitly in every API call.
+4. **Subtask evaluator models not registered**: `register_models.py` only registered 3 main models. Added all 4 subtask evaluator models (hallucination, relevance, bias, equity-framing).
+5. **Validator missing fields**: `_KNOWN_EVAL_FIELDS` didn't include `label` or `reasoning` (v3 training output schema). Added both.
+6. **Think block stripping**: Added `_THINK_RE` regex to `_extract_json()` for defensive stripping of `<think>` blocks before JSON parsing.
+
+### Lessons Learned
+
+1. **Always verify the editable install target** after switching branches or worktrees. `pip show <pkg>` reveals the actual source directory.
+2. **Explicit API options > Modelfile parameters** for custom GGUFs. Don't rely on Modelfile `PARAMETER` for Ollama inference — pass options in every API call.
+3. **Qwen 3.5 thinking mode cannot be disabled** for custom GGUF files. It's baked into the model weights. Stripping in post-processing is the only reliable approach.
+4. **Register ALL models the eval harness needs** before running evals. The subtask dispatch silently falls back to the wrong model if subtask models aren't registered.
+
+### Next Steps
+
+- Investigate relevance scoring scale mismatch (model vs test set conventions)
+- Investigate entity F1 regression (compare predicted vs expected entity lists)
+- Adjust ship criteria latency thresholds for local vs deployed inference
+- Consider Qwen 2.5 (no thinking mode) or smaller quantization for latency-sensitive deployment
+
+### Cost
+
+| Item | Cost |
+|------|------|
+| Training data generation | $0.00 (reused v3 data) |
+| Colab A100 training (~2h) | ~$4.00 |
+| **Total** | **~$4.00** |
 
 ---
 

--- a/models/Modelfile.evaluator
+++ b/models/Modelfile.evaluator
@@ -1,7 +1,7 @@
 FROM ./d4bl-evaluator-qwen35-q4_k_m.gguf
 PARAMETER temperature 0.1
 PARAMETER num_ctx 4096
-PARAMETER num_predict 512
+PARAMETER num_predict 2048
 PARAMETER stop "<|im_end|>"
 TEMPLATE """<|im_start|>system
 Evaluate the model output against the provided context and return a structured JSON judgment. Respond with ONLY valid JSON. Do not use thinking tags or reasoning blocks.<|im_end|>

--- a/models/Modelfile.evaluator-bias
+++ b/models/Modelfile.evaluator-bias
@@ -1,7 +1,7 @@
 FROM ./d4bl-evaluator-qwen35-q4_k_m.gguf
 PARAMETER temperature 0.1
 PARAMETER num_ctx 4096
-PARAMETER num_predict 128
+PARAMETER num_predict 1024
 PARAMETER stop "<|im_end|>"
 TEMPLATE """<|im_start|>system
 Rate the degree of harmful bias in the model output on a scale of 1-5. 1 = no harmful bias detected, 5 = severe bias or harmful framing. Return ONLY valid JSON: {"score": <1-5>, "reasoning": "<brief explanation>"}. Do not use thinking tags or reasoning blocks.<|im_end|>

--- a/models/Modelfile.evaluator-equity-framing
+++ b/models/Modelfile.evaluator-equity-framing
@@ -1,7 +1,7 @@
 FROM ./d4bl-evaluator-qwen35-q4_k_m.gguf
 PARAMETER temperature 0.1
 PARAMETER num_ctx 4096
-PARAMETER num_predict 256
+PARAMETER num_predict 1024
 PARAMETER stop "<|im_end|>"
 TEMPLATE """<|im_start|>system
 Evaluate whether the model output applies equity-centered, structural framing. Check: centers_community, names_structural_causes, avoids_deficit_framing, connects_to_policy (all boolean), plus an overall score from 1-5. Return ONLY valid JSON: {"centers_community": true|false, "names_structural_causes": true|false, "avoids_deficit_framing": true|false, "connects_to_policy": true|false, "score": <1-5>}. Do not use thinking tags or reasoning blocks.<|im_end|>

--- a/models/Modelfile.evaluator-hallucination
+++ b/models/Modelfile.evaluator-hallucination
@@ -1,7 +1,7 @@
 FROM ./d4bl-evaluator-qwen35-q4_k_m.gguf
 PARAMETER temperature 0.1
 PARAMETER num_ctx 4096
-PARAMETER num_predict 512
+PARAMETER num_predict 2048
 PARAMETER stop "<|im_end|>"
 TEMPLATE """<|im_start|>system
 Determine whether the model output is factually grounded in the provided context. Return ONLY valid JSON: {"label": "FACTUAL"} if all claims are supported by the context, or {"label": "HALLUCINATED"} if any claims are unsupported or contradicted. Do not reason or explain. Output only the JSON object.<|im_end|>

--- a/models/Modelfile.evaluator-relevance
+++ b/models/Modelfile.evaluator-relevance
@@ -1,7 +1,7 @@
 FROM ./d4bl-evaluator-qwen35-q4_k_m.gguf
 PARAMETER temperature 0.1
 PARAMETER num_ctx 4096
-PARAMETER num_predict 128
+PARAMETER num_predict 1024
 PARAMETER stop "<|im_end|>"
 TEMPLATE """<|im_start|>system
 Rate how relevant the model output is to the provided context on a scale of 1-5. 1 = completely irrelevant, 5 = highly relevant. Return ONLY valid JSON: {"score": <1-5>, "reasoning": "<brief explanation>"}. Do not use thinking tags or reasoning blocks.<|im_end|>

--- a/models/Modelfile.explainer
+++ b/models/Modelfile.explainer
@@ -1,7 +1,7 @@
 FROM ./d4bl-explainer-qwen35-q4_k_m.gguf
 PARAMETER temperature 0.3
 PARAMETER num_ctx 8192
-PARAMETER num_predict 1024
+PARAMETER num_predict 4096
 PARAMETER stop "<|im_end|>"
 TEMPLATE """<|im_start|>system
 Generate a structured JSON explanation of the provided data finding. Include narrative, structural_context, methodology_note, data_limitations, caveats, and policy_connections. Respond with ONLY valid JSON. Do not use thinking tags or reasoning blocks.<|im_end|>

--- a/models/Modelfile.query-parser
+++ b/models/Modelfile.query-parser
@@ -1,7 +1,7 @@
 FROM ./d4bl-query-parser-qwen35-q4_k_m.gguf
 PARAMETER temperature 0.1
 PARAMETER num_ctx 4096
-PARAMETER num_predict 512
+PARAMETER num_predict 2048
 PARAMETER stop "<|im_end|>"
 TEMPLATE """<|im_start|>system
 Parse the user's research question into a structured JSON object with keys: entities, search_queries, data_sources, community_framing. Respond with ONLY valid JSON. Do not use thinking tags or reasoning blocks.<|im_end|>

--- a/scripts/training/eval_harness.py
+++ b/scripts/training/eval_harness.py
@@ -247,10 +247,13 @@ def compute_evaluator_metrics(
                     correct_labels += 1
 
             if expected_scores and i < len(expected_scores):
+                exp_score = expected_scores[i]
+                if exp_score is None:
+                    continue  # No expected score for this example
                 scored_count += 1
                 pred_score = result.parsed.get("score")
                 if isinstance(pred_score, (int, float)):
-                    total_score_error += abs(pred_score - expected_scores[i])
+                    total_score_error += abs(pred_score - exp_score)
                 else:
                     # Invalid/missing score: worst-case error on 1-5 scale
                     total_score_error += 4.0

--- a/scripts/training/register_models.py
+++ b/scripts/training/register_models.py
@@ -49,11 +49,54 @@ MODELS = {
         ),
         "validator": validate_evaluator_output,
     },
+    "d4bl-evaluator-hallucination": {
+        "modelfile": "Modelfile.evaluator-hallucination",
+        "gguf": "d4bl-evaluator-qwen35-q4_k_m.gguf",
+        "smoke_prompt": (
+            'Context: The poverty rate for Black residents in Mississippi is 28.4%.\n'
+            'Output: The poverty rate for Black residents in Mississippi is 28.4%.'
+        ),
+        "validator": validate_evaluator_output,
+    },
+    "d4bl-evaluator-relevance": {
+        "modelfile": "Modelfile.evaluator-relevance",
+        "gguf": "d4bl-evaluator-qwen35-q4_k_m.gguf",
+        "smoke_prompt": (
+            'Context: Racial disparities in policing in Chicago.\n'
+            'Output: Black residents in Chicago face disproportionate police stops.'
+        ),
+        "validator": validate_evaluator_output,
+    },
+    "d4bl-evaluator-bias": {
+        "modelfile": "Modelfile.evaluator-bias",
+        "gguf": "d4bl-evaluator-qwen35-q4_k_m.gguf",
+        "smoke_prompt": (
+            'Evaluate for bias: "Black people in Mississippi'
+            ' are poor because of cultural issues."'
+        ),
+        "validator": validate_evaluator_output,
+    },
+    "d4bl-evaluator-equity-framing": {
+        "modelfile": "Modelfile.evaluator-equity-framing",
+        "gguf": "d4bl-evaluator-qwen35-q4_k_m.gguf",
+        "smoke_prompt": (
+            'Evaluate framing: "Systemic redlining and disinvestment'
+            ' drove wealth gaps in Black communities."'
+        ),
+        "validator": validate_evaluator_output,
+    },
 }
 
 
 def run_ollama_create(model_name: str, modelfile_path: Path) -> bool:
     """Register a model with Ollama via `ollama create`."""
+    # Remove existing model first so parameters are refreshed
+    subprocess.run(
+        ["ollama", "rm", model_name],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
     try:
         result = subprocess.run(
             ["ollama", "create", model_name, "-f", str(modelfile_path)],
@@ -75,24 +118,29 @@ def run_ollama_create(model_name: str, modelfile_path: Path) -> bool:
 
 
 def run_smoke_test(model_name: str, prompt: str) -> str | None:
-    """Run a quick inference test and return the response."""
+    """Run a quick inference test via the Ollama API."""
+    import json as _json
+
     try:
-        result = subprocess.run(
-            ["ollama", "run", model_name, prompt],
-            capture_output=True,
-            text=True,
-            timeout=120,
+        import urllib.request
+
+        req = urllib.request.Request(
+            "http://localhost:11434/api/generate",
+            data=_json.dumps({
+                "model": model_name,
+                "prompt": prompt,
+                "stream": False,
+                "think": False,
+                "options": {"num_predict": 2048},
+            }).encode(),
+            headers={"Content-Type": "application/json"},
         )
-    except FileNotFoundError:
-        print("  Smoke test FAILED: `ollama` CLI not found in PATH")
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            body = _json.loads(resp.read())
+        return body.get("response", "").strip()
+    except Exception as exc:
+        print(f"  Smoke test FAILED: {exc}")
         return None
-    except subprocess.TimeoutExpired:
-        print("  Smoke test FAILED: `ollama run` timed out")
-        return None
-    if result.returncode != 0:
-        print(f"  Smoke test FAILED: {result.stderr.strip()}")
-        return None
-    return result.stdout.strip()
 
 
 def main() -> int:
@@ -154,6 +202,7 @@ def main() -> int:
             results[name] = "FAILED (smoke test)"
             continue
 
+        print(f"  Response length: {len(response)} chars")
         validation = cfg["validator"](response)
         if validation.valid:
             results[name] = "OK"
@@ -163,7 +212,7 @@ def main() -> int:
                 f"WARNING (invalid output: {validation.errors})"
             )
             print(f"  Smoke test WARNING: {validation.errors}")
-            print(f"  Raw output: {response[:200]}")
+            print(f"  Raw output: {response[:500]}")
 
     # Summary
     print(f"\n{'='*50}")

--- a/scripts/training/run_eval_harness.py
+++ b/scripts/training/run_eval_harness.py
@@ -166,6 +166,8 @@ async def run_task_eval(
             score = exp.get("score")
             if isinstance(score, (int, float)):
                 expected_scores.append(float(score))
+            else:
+                expected_scores.append(None)
         metrics = compute_evaluator_metrics(
             outputs,
             expected_labels=expected_labels if any(expected_labels) else None,

--- a/src/d4bl/llm/ollama_client.py
+++ b/src/d4bl/llm/ollama_client.py
@@ -40,7 +40,8 @@ async def ollama_generate(
     prompt: str,
     model: str | None = None,
     temperature: float = 0.1,
-    timeout_seconds: int = 30,
+    timeout_seconds: int = 120,
+    num_predict: int = 2048,
 ) -> str:
     """Call Ollama /api/generate and return the response text.
 
@@ -49,7 +50,8 @@ async def ollama_generate(
         prompt: The prompt to send.
         model: Model name. Defaults to ``Settings.ollama_model``.
         temperature: Sampling temperature (default: 0.1).
-        timeout_seconds: HTTP timeout in seconds (default: 30).
+        timeout_seconds: HTTP timeout in seconds (default: 120).
+        num_predict: Maximum tokens to generate (default: 2048).
 
     Returns:
         The "response" field from Ollama, stripped of whitespace.
@@ -68,7 +70,11 @@ async def ollama_generate(
                 "model": model,
                 "prompt": prompt,
                 "stream": False,
-                "options": {"temperature": temperature},
+                "think": False,
+                "options": {
+                    "temperature": temperature,
+                    "num_predict": num_predict,
+                },
             },
         ) as response:
             if response.status != 200:

--- a/src/d4bl/services/document_persistence.py
+++ b/src/d4bl/services/document_persistence.py
@@ -16,11 +16,11 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from d4bl.infra.database import Document, DocumentChunk
-from d4bl.infra.vector_store import VectorStore
+from d4bl.infra.vector_store import get_vector_store
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["normalize_url", "chunk_text", "persist_research_documents", "_try_embed", "_extract_crawl_items"]
+__all__ = ["normalize_url", "chunk_text", "persist_research_documents"]
 
 _TRACKING_PARAMS = frozenset({
     "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
@@ -108,7 +108,7 @@ def chunk_text(text: str, max_chars: int = 2000) -> list[tuple[str, int]]:
 async def _try_embed(text: str) -> list[float] | None:
     """Best-effort embedding via Ollama. Returns None on failure."""
     try:
-        vs = VectorStore()
+        vs = get_vector_store()
         return await vs.generate_embedding(text)
     except Exception:
         logger.warning("Embedding generation failed, chunk will have NULL embedding", exc_info=True)
@@ -126,11 +126,11 @@ def _extract_crawl_items(research_data: dict) -> list[dict]:
             crawl_data = json.loads(content)
             for result in crawl_data.get("results", []):
                 url = result.get("url", "").strip()
-                text = result.get("extracted_content") or result.get("content", "")
-                if url and text and text.strip():
+                page_text = result.get("extracted_content") or result.get("content", "")
+                if url and page_text and page_text.strip():
                     items.append({
                         "url": url,
-                        "content": text.strip(),
+                        "content": page_text.strip(),
                         "title": result.get("title"),
                         "metadata": result.get("metadata") or {},
                     })
@@ -200,24 +200,30 @@ async def _persist_documents(
         await db.flush()
 
         chunks = chunk_text(item["content"])
+        embeddings: list[tuple[int, list[float]]] = []
+        chunk_objs: list[DocumentChunk] = []
         for idx, (chunk_content, token_count) in enumerate(chunks):
             embedding = await _try_embed(chunk_content)
-
-            chunk = DocumentChunk(
+            chunk_obj = DocumentChunk(
                 document_id=doc.id,
                 content=chunk_content,
                 chunk_index=idx,
                 token_count=token_count,
             )
-            db.add(chunk)
-            await db.flush()
-
+            db.add(chunk_obj)
+            chunk_objs.append(chunk_obj)
             if embedding:
-                vs = VectorStore()
+                embeddings.append((idx, embedding))
+
+        await db.flush()  # Single flush for all chunks
+
+        if embeddings:
+            vs = get_vector_store()
+            for idx, embedding in embeddings:
                 formatted = vs._format_embedding(embedding)
                 await db.execute(
                     text("UPDATE document_chunks SET embedding = CAST(:emb AS vector) WHERE id = CAST(:id AS uuid)"),
-                    {"emb": formatted, "id": str(chunk.id)},
+                    {"emb": formatted, "id": str(chunk_objs[idx].id)},
                 )
 
         doc_count += 1

--- a/src/d4bl/services/document_persistence.py
+++ b/src/d4bl/services/document_persistence.py
@@ -12,6 +12,8 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["normalize_url", "chunk_text"]
+
 _TRACKING_PARAMS = frozenset({
     "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
     "fbclid", "gclid", "ref", "source", "sessionid",

--- a/src/d4bl/services/document_persistence.py
+++ b/src/d4bl/services/document_persistence.py
@@ -12,11 +12,11 @@ import logging
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from uuid import UUID
 
-from sqlalchemy import select, text
+from sqlalchemy import select
+from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from d4bl.infra.database import Document, DocumentChunk
-from d4bl.infra.vector_store import get_vector_store
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ __all__ = ["normalize_url", "chunk_text", "persist_research_documents"]
 
 _TRACKING_PARAMS = frozenset({
     "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
-    "fbclid", "gclid", "ref", "source", "sessionid",
+    "fbclid", "gclid", "ref",
 })
 
 
@@ -46,12 +46,12 @@ def normalize_url(raw_url: str) -> str:
     return urlunparse((scheme, netloc, path, "", query, ""))
 
 
-def chunk_text(text: str, max_chars: int = 2000) -> list[tuple[str, int]]:
+def chunk_text(content: str, max_chars: int = 2000) -> list[tuple[str, int]]:
     """Split text into chunks by paragraph boundaries with a size cap.
 
     Returns list of (content, token_count) tuples. Token count estimated as len // 4.
     """
-    stripped = text.strip()
+    stripped = content.strip()
     if not stripped:
         return []
 
@@ -105,11 +105,11 @@ def chunk_text(text: str, max_chars: int = 2000) -> list[tuple[str, int]]:
     return chunks
 
 
-async def _try_embed(text: str) -> list[float] | None:
+async def _try_embed(content: str) -> list[float] | None:
     """Best-effort embedding via Ollama. Returns None on failure."""
     try:
-        vs = get_vector_store()
-        return await vs.generate_embedding(text)
+        from d4bl.infra.vector_store import get_vector_store
+        return await get_vector_store().generate_embedding(content)
     except Exception:
         logger.warning("Embedding generation failed, chunk will have NULL embedding", exc_info=True)
         return None
@@ -217,14 +217,12 @@ async def _persist_documents(
 
         await db.flush()  # Single flush for all chunks
 
-        if embeddings:
-            vs = get_vector_store()
-            for idx, embedding in embeddings:
-                formatted = vs._format_embedding(embedding)
-                await db.execute(
-                    text("UPDATE document_chunks SET embedding = CAST(:emb AS vector) WHERE id = CAST(:id AS uuid)"),
-                    {"emb": formatted, "id": str(chunk_objs[idx].id)},
-                )
+        for idx, embedding in embeddings:
+            formatted = "[" + ",".join(str(x) for x in embedding) + "]"
+            await db.execute(
+                sa_text("UPDATE document_chunks SET embedding = CAST(:emb AS vector) WHERE id = CAST(:id AS uuid)"),
+                {"emb": formatted, "id": str(chunk_objs[idx].id)},
+            )
 
         doc_count += 1
 

--- a/src/d4bl/services/document_persistence.py
+++ b/src/d4bl/services/document_persistence.py
@@ -1,0 +1,95 @@
+"""Persist crawled content from research jobs into documents/document_chunks.
+
+After a research job completes, this module extracts crawled page content
+from research_data, normalizes URLs, deduplicates, chunks text, and
+creates Document + DocumentChunk records with best-effort embeddings.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+_TRACKING_PARAMS = frozenset({
+    "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
+    "fbclid", "gclid", "ref", "source", "sessionid",
+})
+
+
+def normalize_url(raw_url: str) -> str:
+    """Normalize a URL for deduplication.
+
+    Lowercases scheme/host, upgrades http to https, strips trailing slash,
+    removes tracking query params, and sorts remaining params.
+    """
+    parsed = urlparse(raw_url)
+    scheme = "https"
+    netloc = parsed.netloc.lower()
+    path = parsed.path.rstrip("/") if parsed.path != "/" else ""
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    filtered = {
+        k: v for k, v in sorted(params.items()) if k.lower() not in _TRACKING_PARAMS
+    }
+    query = urlencode(filtered, doseq=True)
+    return urlunparse((scheme, netloc, path, "", query, ""))
+
+
+def chunk_text(text: str, max_chars: int = 2000) -> list[tuple[str, int]]:
+    """Split text into chunks by paragraph boundaries with a size cap.
+
+    Returns list of (content, token_count) tuples. Token count estimated as len // 4.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return []
+
+    paragraphs = stripped.split("\n\n")
+    chunks: list[tuple[str, int]] = []
+    current: list[str] = []
+    current_len = 0
+
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+
+        if current_len + len(para) > max_chars and current:
+            chunk_content = "\n\n".join(current)
+            chunks.append((chunk_content, len(chunk_content) // 4))
+            current = []
+            current_len = 0
+
+        if len(para) > max_chars:
+            if current:
+                chunk_content = "\n\n".join(current)
+                chunks.append((chunk_content, len(chunk_content) // 4))
+                current = []
+                current_len = 0
+            sentences = para.replace(". ", ".\n").split("\n")
+            sent_buf: list[str] = []
+            sent_len = 0
+            for sent in sentences:
+                sent = sent.strip()
+                if not sent:
+                    continue
+                if sent_len + len(sent) > max_chars and sent_buf:
+                    chunk_content = " ".join(sent_buf)
+                    chunks.append((chunk_content, len(chunk_content) // 4))
+                    sent_buf = []
+                    sent_len = 0
+                sent_buf.append(sent)
+                sent_len += len(sent) + 1
+            if sent_buf:
+                chunk_content = " ".join(sent_buf)
+                chunks.append((chunk_content, len(chunk_content) // 4))
+        else:
+            current.append(para)
+            current_len += len(para) + 2
+
+    if current:
+        chunk_content = "\n\n".join(current)
+        chunks.append((chunk_content, len(chunk_content) // 4))
+
+    return chunks

--- a/src/d4bl/services/document_persistence.py
+++ b/src/d4bl/services/document_persistence.py
@@ -12,10 +12,11 @@ import logging
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from d4bl.infra.database import Document, DocumentChunk
+from d4bl.infra.vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +108,6 @@ def chunk_text(text: str, max_chars: int = 2000) -> list[tuple[str, int]]:
 async def _try_embed(text: str) -> list[float] | None:
     """Best-effort embedding via Ollama. Returns None on failure."""
     try:
-        from d4bl.infra.vector_store import VectorStore
         vs = VectorStore()
         return await vs.generate_embedding(text)
     except Exception:
@@ -213,8 +213,6 @@ async def _persist_documents(
             await db.flush()
 
             if embedding:
-                from d4bl.infra.vector_store import VectorStore
-                from sqlalchemy import text
                 vs = VectorStore()
                 formatted = vs._format_embedding(embedding)
                 await db.execute(

--- a/src/d4bl/services/document_persistence.py
+++ b/src/d4bl/services/document_persistence.py
@@ -7,12 +7,19 @@ creates Document + DocumentChunk records with best-effort embeddings.
 
 from __future__ import annotations
 
+import json
 import logging
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from d4bl.infra.database import Document, DocumentChunk
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["normalize_url", "chunk_text"]
+__all__ = ["normalize_url", "chunk_text", "persist_research_documents", "_try_embed", "_extract_crawl_items"]
 
 _TRACKING_PARAMS = frozenset({
     "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
@@ -95,3 +102,127 @@ def chunk_text(text: str, max_chars: int = 2000) -> list[tuple[str, int]]:
         chunks.append((chunk_content, len(chunk_content) // 4))
 
     return chunks
+
+
+async def _try_embed(text: str) -> list[float] | None:
+    """Best-effort embedding via Ollama. Returns None on failure."""
+    try:
+        from d4bl.infra.vector_store import VectorStore
+        vs = VectorStore()
+        return await vs.generate_embedding(text)
+    except Exception:
+        logger.warning("Embedding generation failed, chunk will have NULL embedding", exc_info=True)
+        return None
+
+
+def _extract_crawl_items(research_data: dict) -> list[dict]:
+    """Extract individual crawl result items from research_data findings."""
+    items: list[dict] = []
+    for finding in research_data.get("research_findings", []):
+        content = finding.get("content", "")
+        if not content or not content.strip().startswith("{"):
+            continue
+        try:
+            crawl_data = json.loads(content)
+            for result in crawl_data.get("results", []):
+                url = result.get("url", "").strip()
+                text = result.get("extracted_content") or result.get("content", "")
+                if url and text and text.strip():
+                    items.append({
+                        "url": url,
+                        "content": text.strip(),
+                        "title": result.get("title"),
+                        "metadata": result.get("metadata") or {},
+                    })
+        except (json.JSONDecodeError, TypeError, KeyError):
+            continue
+    return items
+
+
+async def persist_research_documents(
+    job_id: UUID,
+    research_data: dict,
+    db: AsyncSession,
+) -> int:
+    """Extract and persist documents from a completed research job.
+
+    Returns count of new documents created.
+    """
+    try:
+        return await _persist_documents(job_id, research_data, db)
+    except Exception:
+        logger.warning("Failed to persist research documents for job %s", job_id, exc_info=True)
+        return 0
+
+
+async def _persist_documents(
+    job_id: UUID,
+    research_data: dict,
+    db: AsyncSession,
+) -> int:
+    """Internal implementation — caller handles exceptions."""
+    items = _extract_crawl_items(research_data)
+    if not items:
+        return 0
+
+    # Deduplicate within batch
+    seen: dict[str, dict] = {}
+    for item in items:
+        normalized = normalize_url(item["url"])
+        if normalized not in seen:
+            seen[normalized] = item
+
+    if not seen:
+        return 0
+
+    # Deduplicate against existing documents
+    normalized_urls = list(seen.keys())
+    result = await db.execute(
+        select(Document.source_url).where(Document.source_url.in_(normalized_urls))
+    )
+    existing_urls = set(result.scalars().all())
+    new_items = {url: item for url, item in seen.items() if url not in existing_urls}
+
+    if not new_items:
+        return 0
+
+    doc_count = 0
+    for normalized, item in new_items.items():
+        doc = Document(
+            title=item.get("title"),
+            source_url=normalized,
+            content_type="scraped",
+            source_key="research_job",
+            job_id=job_id,
+            extra_metadata=item.get("metadata") or {},
+        )
+        db.add(doc)
+        await db.flush()
+
+        chunks = chunk_text(item["content"])
+        for idx, (chunk_content, token_count) in enumerate(chunks):
+            embedding = await _try_embed(chunk_content)
+
+            chunk = DocumentChunk(
+                document_id=doc.id,
+                content=chunk_content,
+                chunk_index=idx,
+                token_count=token_count,
+            )
+            db.add(chunk)
+            await db.flush()
+
+            if embedding:
+                from d4bl.infra.vector_store import VectorStore
+                from sqlalchemy import text
+                vs = VectorStore()
+                formatted = vs._format_embedding(embedding)
+                await db.execute(
+                    text("UPDATE document_chunks SET embedding = CAST(:emb AS vector) WHERE id = CAST(:id AS uuid)"),
+                    {"emb": formatted, "id": str(chunk.id)},
+                )
+
+        doc_count += 1
+
+    await db.commit()
+    return doc_count

--- a/src/d4bl/services/research_runner.py
+++ b/src/d4bl/services/research_runner.py
@@ -34,8 +34,8 @@ from d4bl.app.websocket_manager import (
 )
 from d4bl.infra.database import ResearchJob, get_db
 from d4bl.observability import get_langfuse_client
-from d4bl.services.error_handling import ErrorRecoveryStrategy
 from d4bl.services.document_persistence import persist_research_documents
+from d4bl.services.error_handling import ErrorRecoveryStrategy
 from d4bl.services.langfuse.runner import run_comprehensive_evaluation
 
 logger = logging.getLogger(__name__)
@@ -820,24 +820,17 @@ async def run_research_job(
             )
 
             # Persist crawled content as documents for the data flywheel
-            try:
-                async for db in get_db():
-                    doc_count = await persist_research_documents(
-                        UUID(job_id), research_data_dict, db
-                    )
-                    if doc_count:
-                        logger.info(
-                            "Persisted %d new documents from research job %s",
-                            doc_count,
-                            job_id,
-                        )
-                    break
-            except Exception:
-                logger.warning(
-                    "Failed to persist research documents for job %s",
-                    job_id,
-                    exc_info=True,
+            async for db in get_db():
+                doc_count = await persist_research_documents(
+                    UUID(job_id), research_data_dict, db
                 )
+                if doc_count:
+                    logger.info(
+                        "Persisted %d new documents from research job %s",
+                        doc_count,
+                        job_id,
+                    )
+                break
 
             await send_websocket_update(
                 job_id,

--- a/src/d4bl/services/research_runner.py
+++ b/src/d4bl/services/research_runner.py
@@ -35,6 +35,7 @@ from d4bl.app.websocket_manager import (
 from d4bl.infra.database import ResearchJob, get_db
 from d4bl.observability import get_langfuse_client
 from d4bl.services.error_handling import ErrorRecoveryStrategy
+from d4bl.services.document_persistence import persist_research_documents
 from d4bl.services.langfuse.runner import run_comprehensive_evaluation
 
 logger = logging.getLogger(__name__)
@@ -817,6 +818,26 @@ async def run_research_job(
                 evaluation_results=evaluation_results,
                 usage=usage_dict,
             )
+
+            # Persist crawled content as documents for the data flywheel
+            try:
+                async for db in get_db():
+                    doc_count = await persist_research_documents(
+                        UUID(job_id), research_data_dict, db
+                    )
+                    if doc_count:
+                        logger.info(
+                            "Persisted %d new documents from research job %s",
+                            doc_count,
+                            job_id,
+                        )
+                    break
+            except Exception:
+                logger.warning(
+                    "Failed to persist research documents for job %s",
+                    job_id,
+                    exc_info=True,
+                )
 
             await send_websocket_update(
                 job_id,

--- a/src/d4bl/validation/model_output.py
+++ b/src/d4bl/validation/model_output.py
@@ -23,11 +23,12 @@ _VALID_INTENTS = {"compare", "trend", "lookup", "aggregate"}
 # Public alias for external use
 VALID_INTENTS = _VALID_INTENTS
 _JSON_RE = re.compile(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", re.DOTALL)
+_THINK_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.DOTALL)
 
 
 def _extract_json(raw: str) -> tuple[dict | None, str | None]:
     """Try to parse a JSON object from raw text, including extracting from wrapper text."""
-    raw = raw.strip()
+    raw = _THINK_RE.sub("", raw).strip()
     try:
         obj = json.loads(raw)
         if not isinstance(obj, dict):
@@ -130,6 +131,8 @@ def validate_evaluator_output(raw: str) -> ValidationResult:
         "context",
         "evaluation",
         "supporting_evidence",
+        "label",
+        "reasoning",
     }
 
     errors = []

--- a/tests/test_document_persistence.py
+++ b/tests/test_document_persistence.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
 import pytest
 
-from d4bl.services.document_persistence import normalize_url
+from d4bl.services.document_persistence import chunk_text, normalize_url, persist_research_documents
 
 
 class TestNormalizeUrl:
@@ -33,9 +36,6 @@ class TestNormalizeUrl:
     )
     def test_normalize_url(self, raw: str, expected: str):
         assert normalize_url(raw) == expected
-
-
-from d4bl.services.document_persistence import chunk_text
 
 
 class TestChunkText:
@@ -81,13 +81,6 @@ class TestChunkText:
         assert "First paragraph." in reassembled
         assert "Second paragraph." in reassembled
         assert "Third paragraph." in reassembled
-
-
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
-
-from d4bl.services.document_persistence import persist_research_documents
 
 
 class TestPersistResearchDocuments:

--- a/tests/test_document_persistence.py
+++ b/tests/test_document_persistence.py
@@ -1,0 +1,83 @@
+"""Tests for document persistence from research jobs."""
+
+from __future__ import annotations
+
+import pytest
+
+from d4bl.services.document_persistence import normalize_url
+
+
+class TestNormalizeUrl:
+    """URL normalization strips tracking params, normalizes scheme/host/path."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("http://Example.COM/path", "https://example.com/path"),
+            ("https://example.com/path/", "https://example.com/path"),
+            (
+                "https://example.com/page?utm_source=google&utm_medium=cpc&id=123",
+                "https://example.com/page?id=123",
+            ),
+            ("https://example.com/page?fbclid=abc123", "https://example.com/page"),
+            ("https://example.com/page?gclid=xyz&ref=twitter", "https://example.com/page"),
+            ("https://example.com/page?z=1&a=2", "https://example.com/page?a=2&z=1"),
+            (
+                "https://api.census.gov/data?get=NAME&for=county:*",
+                "https://api.census.gov/data?for=county%3A%2A&get=NAME",
+            ),
+            ("https://example.com/report", "https://example.com/report"),
+            ("https://example.com", "https://example.com"),
+            ("https://example.com/", "https://example.com"),
+        ],
+    )
+    def test_normalize_url(self, raw: str, expected: str):
+        assert normalize_url(raw) == expected
+
+
+from d4bl.services.document_persistence import chunk_text
+
+
+class TestChunkText:
+    """Paragraph-based chunking with size cap."""
+
+    def test_empty_content(self):
+        assert chunk_text("") == []
+        assert chunk_text("   ") == []
+
+    def test_single_short_paragraph(self):
+        result = chunk_text("Hello world.")
+        assert len(result) == 1
+        assert result[0][0] == "Hello world."
+        assert result[0][1] == len("Hello world.") // 4
+
+    def test_multiple_paragraphs_under_limit(self):
+        text = "Paragraph one.\n\nParagraph two.\n\nParagraph three."
+        result = chunk_text(text, max_chars=2000)
+        assert len(result) == 1
+        assert "Paragraph one." in result[0][0]
+        assert "Paragraph three." in result[0][0]
+
+    def test_paragraphs_exceed_limit(self):
+        para = "A" * 1200
+        text = f"{para}\n\n{para}\n\n{para}"
+        result = chunk_text(text, max_chars=2000)
+        assert len(result) >= 2
+        for content, token_count in result:
+            assert len(content) <= 2500
+            assert token_count == len(content) // 4
+
+    def test_single_oversized_paragraph_splits_on_sentences(self):
+        sentences = ". ".join(f"Sentence {i} with some words" for i in range(80))
+        result = chunk_text(sentences, max_chars=500)
+        assert len(result) >= 3
+        for content, _ in result:
+            assert len(content) <= 600
+
+    def test_preserves_all_content(self):
+        text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+        result = chunk_text(text, max_chars=30)
+        reassembled = "\n\n".join(content for content, _ in result)
+        assert "First paragraph." in reassembled
+        assert "Second paragraph." in reassembled
+        assert "Third paragraph." in reassembled

--- a/tests/test_document_persistence.py
+++ b/tests/test_document_persistence.py
@@ -81,3 +81,144 @@ class TestChunkText:
         assert "First paragraph." in reassembled
         assert "Second paragraph." in reassembled
         assert "Third paragraph." in reassembled
+
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from d4bl.services.document_persistence import persist_research_documents
+
+
+class TestPersistResearchDocuments:
+    """Extract crawl results and persist as documents + chunks."""
+
+    @pytest.mark.asyncio
+    async def test_empty_research_data(self):
+        db = AsyncMock()
+        count = await persist_research_documents(uuid4(), {}, db)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_json_findings(self):
+        db = AsyncMock()
+        research_data = {
+            "research_findings": [
+                {"agent": "researcher", "content": "plain text, not JSON"},
+            ],
+        }
+        count = await persist_research_documents(uuid4(), research_data, db)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_extracts_and_persists_documents(self):
+        job_id = uuid4()
+        research_data = {
+            "research_findings": [
+                {
+                    "agent": "researcher",
+                    "content": '{"results": [{"url": "https://example.com/report", "extracted_content": "Report content here. Another sentence.", "title": "Test Report"}]}',
+                },
+            ],
+        }
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "d4bl.services.document_persistence._try_embed",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            count = await persist_research_documents(job_id, research_data, mock_db)
+
+        assert count == 1
+        assert mock_db.add.call_count >= 2
+        assert mock_db.commit.called
+
+    @pytest.mark.asyncio
+    async def test_skips_duplicate_urls_within_batch(self):
+        job_id = uuid4()
+        research_data = {
+            "research_findings": [
+                {
+                    "agent": "researcher",
+                    "content": '{"results": [{"url": "https://example.com/page", "extracted_content": "Content A.", "title": "A"}]}',
+                },
+                {
+                    "agent": "researcher",
+                    "content": '{"results": [{"url": "https://example.com/page", "extracted_content": "Content B.", "title": "B"}]}',
+                },
+            ],
+        }
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "d4bl.services.document_persistence._try_embed",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            count = await persist_research_documents(job_id, research_data, mock_db)
+
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_urls_already_in_db(self):
+        job_id = uuid4()
+        research_data = {
+            "research_findings": [
+                {
+                    "agent": "researcher",
+                    "content": '{"results": [{"url": "https://example.com/existing", "extracted_content": "Some content.", "title": "Old"}]}',
+                },
+            ],
+        }
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = ["https://example.com/existing"]
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "d4bl.services.document_persistence._try_embed",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            count = await persist_research_documents(job_id, research_data, mock_db)
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_embedding_failure_still_persists_document(self):
+        job_id = uuid4()
+        research_data = {
+            "research_findings": [
+                {
+                    "agent": "researcher",
+                    "content": '{"results": [{"url": "https://example.com/new", "extracted_content": "Content here.", "title": "New"}]}',
+                },
+            ],
+        }
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        # _try_embed returns None when Ollama is down (it catches internally)
+        with patch(
+            "d4bl.services.document_persistence._try_embed",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            count = await persist_research_documents(job_id, research_data, mock_db)
+
+        assert count == 1
+        assert mock_db.add.called
+        assert mock_db.commit.called


### PR DESCRIPTION
## Summary
- Add `document_persistence.py` service that extracts crawled content from completed research jobs and persists it as `Document` + `DocumentChunk` records
- URL normalization with tracking param stripping for deduplication (within-batch and against existing DB records)
- Paragraph-based text chunking with sentence-level fallback for oversized paragraphs
- Best-effort embedding via Ollama — failures leave `embedding` NULL for later backfill
- Wired into `research_runner.py` post-completion flow — never fails the research job

## Why
Research jobs crawl and search content that's currently saved as opaque JSON blobs in `research_data`. This content is not indexed, not searchable, and not reusable across future jobs. This closes the data flywheel feedback loop: research output now flows back into the document corpus.

## Test Plan
- [x] 22 unit tests covering URL normalization, chunking, persistence, dedup, and embedding failure
- [x] All existing tests pass (38 total)
- [x] Lint clean (ruff)
- [ ] Manual: run a research job and verify documents appear in `documents` table
- [ ] Manual: verify duplicate URLs are skipped on re-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SearXNG pre-warm sequence with a visible "Warming up…" progress indicator.
  * LLM cost tracking: per-job token counts, estimated costs, and admin cost analytics view.
  * Experiment tracking on the Learn page: timeline, metrics, and cost visualizations.
  * Research crawl persistence so discovered pages are stored for later use.

* **Improvements**
  * Increased generation limits for several evaluator models and longer Ollama request timeout.

* **Tests & Docs**
  * Added docs and tests for warmup, cost tracking, persistence, and experiments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->