### PR TITLE
feat(explore): surface policy bills as top-level data source tab

### DIFF
--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -1865,6 +1865,10 @@ async def get_policies(
         if topic is not None:
             # JSON array containment: cast topic_tags to text and use LIKE
             query = query.where(PolicyBill.topic_tags.cast(String).contains(topic))
+        # Order by recency so the client-side `limit` slice is actually the
+        # newest N, not an arbitrary subset. NULLS LAST keeps bills with no
+        # last_action_date from dominating the top of the feed.
+        query = query.order_by(PolicyBill.last_action_date.desc().nullslast())
         query = query.limit(max(1, min(limit, 5000)))
         result = await db.execute(query)
         rows = result.scalars().all()

--- a/ui-nextjs/app/explore/page.tsx
+++ b/ui-nextjs/app/explore/page.tsx
@@ -8,6 +8,7 @@ import DataSourceTabs from '@/components/explore/DataSourceTabs';
 import EmptyDataState from '@/components/explore/EmptyDataState';
 import StateVsNationalChart from '@/components/explore/StateVsNationalChart';
 import PolicyBadge from '@/components/explore/PolicyBadge';
+import PolicyExploreView from '@/components/explore/PolicyExploreView';
 import StateAnnotation from '@/components/explore/StateAnnotation';
 import ExplainPanel from '@/components/explore/ExplainPanel';
 import ExploreQueryBar from '@/components/explore/ExploreQueryBar';
@@ -135,6 +136,13 @@ export default function ExplorePage() {
   /** Unified data fetching for all sources. */
   const fetchData = useCallback(async (signal: AbortSignal) => {
     if (!session?.access_token) return;
+    // Policy tab owns its own bills fetch in PolicyExploreView — skip the
+    // metric-oriented fetch entirely so we don't hit a metric endpoint that
+    // doesn't exist for 'policy'.
+    if (activeSource.key === 'policy') {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
 
@@ -285,12 +293,16 @@ export default function ExplorePage() {
           </div>
         </div>
 
-        {error && (
+        {error && activeSource.key !== 'policy' && (
           <div className="mb-4 px-4 py-3 bg-red-900/30 border border-red-800 rounded text-red-300 text-sm">
             Error loading data: {error}
           </div>
         )}
 
+        {activeSource.key === 'policy' ? (
+          <PolicyExploreView />
+        ) : (
+          <>
         {/* Map + Filters */}
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_260px] gap-4 mb-6">
           <div>
@@ -439,6 +451,8 @@ export default function ExplorePage() {
             year={resolvedYear}
             accent={activeSource.accent}
           />
+        )}
+          </>
         )}
       </div>
     </div>

--- a/ui-nextjs/app/globals.css
+++ b/ui-nextjs/app/globals.css
@@ -107,7 +107,7 @@ button {
 }
 
 /* Policy Bills feed: stagger-fade entrance for BillFeedRow. */
-@keyframes billFadeIn {
+@keyframes bill-fade-in {
   from {
     opacity: 0;
     transform: translateY(4px);
@@ -119,7 +119,7 @@ button {
 }
 
 .bill-fade-in {
-  animation: billFadeIn 360ms ease-out both;
+  animation: bill-fade-in 360ms ease-out both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/ui-nextjs/app/globals.css
+++ b/ui-nextjs/app/globals.css
@@ -105,3 +105,25 @@ button {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
+
+/* Policy Bills feed: stagger-fade entrance for BillFeedRow. */
+@keyframes billFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.bill-fade-in {
+  animation: billFadeIn 360ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bill-fade-in {
+    animation: none !important;
+  }
+}

--- a/ui-nextjs/components/explore/BillFeedRow.tsx
+++ b/ui-nextjs/components/explore/BillFeedRow.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { PolicyBill } from '@/lib/types';
+import { formatRelativeDate, statusToPhase } from '@/lib/explore-config';
+import PhaseGlyph from './PhaseGlyph';
+
+interface Props {
+  bill: PolicyBill;
+  pulse?: boolean;
+  staggerIndex?: number;
+}
+
+export default function BillFeedRow({ bill, pulse = false, staggerIndex }: Props) {
+  const phase = statusToPhase(bill.status);
+  const relativeDate = formatRelativeDate(bill.last_action_date);
+  const shouldStagger = staggerIndex != null;
+
+  return (
+    <article
+      className={`py-4 border-b border-[#2a2a2a] last:border-b-0 flex items-start gap-4${
+        shouldStagger ? ' bill-fade-in' : ''
+      }`}
+      style={shouldStagger ? { animationDelay: `${staggerIndex! * 40}ms` } : undefined}
+    >
+      <div className="pt-1 shrink-0">
+        <PhaseGlyph phase={phase} pulse={pulse} />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <span className="text-xs font-mono text-gray-500">{bill.bill_number}</span>
+          <span
+            className="text-[10px] font-mono uppercase tracking-wider text-gray-500"
+            aria-hidden="true"
+          >
+            ·
+          </span>
+          <span className="text-xs font-mono text-gray-500">{phase.label}</span>
+          {bill.topic_tags && bill.topic_tags.length > 0 && (
+            <>
+              <span
+                className="text-[10px] font-mono uppercase tracking-wider text-gray-500"
+                aria-hidden="true"
+              >
+                ·
+              </span>
+              <div className="flex flex-wrap gap-1">
+                {bill.topic_tags.slice(0, 3).map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-1.5 py-0.5 rounded bg-[#2a2a2a] text-[10px] text-gray-400 capitalize"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+
+        <p className="text-sm text-gray-200 leading-snug mb-1 line-clamp-2">{bill.title}</p>
+
+        <p className="text-xs font-mono text-gray-600">last action {relativeDate}</p>
+      </div>
+
+      {bill.url && (
+        <a
+          href={bill.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 self-center text-xs font-mono text-[#00ff32] hover:underline whitespace-nowrap"
+        >
+          view →
+        </a>
+      )}
+    </article>
+  );
+}

--- a/ui-nextjs/components/explore/BillFeedRow.tsx
+++ b/ui-nextjs/components/explore/BillFeedRow.tsx
@@ -68,6 +68,7 @@ export default function BillFeedRow({ bill, pulse = false, staggerIndex }: Props
           href={bill.url}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label={`View ${bill.bill_number}: ${bill.title}`}
           className="shrink-0 self-center text-xs font-mono text-[#00ff32] hover:underline whitespace-nowrap"
         >
           view →

--- a/ui-nextjs/components/explore/PhaseGlyph.tsx
+++ b/ui-nextjs/components/explore/PhaseGlyph.tsx
@@ -43,7 +43,7 @@ export default function PhaseGlyph({ status, phase, pulse = false }: Props) {
             aria-hidden="true"
             className={
               pulse && isLastFilled
-                ? 'inline-block w-2 h-2.5 rounded-[1px] animate-pulse'
+                ? 'inline-block w-2 h-2.5 rounded-[1px] animate-pulse motion-reduce:animate-none'
                 : 'inline-block w-2 h-2.5 rounded-[1px]'
             }
             style={{

--- a/ui-nextjs/components/explore/PhaseGlyph.tsx
+++ b/ui-nextjs/components/explore/PhaseGlyph.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { BillPhase, PHASE_GLYPH_SEGMENTS, statusToPhase } from '@/lib/explore-config';
+
+interface Props {
+  /** Raw bill status; ignored if `phase` is provided directly. */
+  status?: string | null;
+  /** Optional pre-computed phase; if omitted, derived from `status`. */
+  phase?: BillPhase;
+  /** If true, the final filled segment pulses subtly (for most-recent row). */
+  pulse?: boolean;
+}
+
+const TONE_COLORS: Record<BillPhase['tone'], { filled: string; dim: string }> = {
+  active: { filled: '#00ff32', dim: '#00ff3222' },
+  signed: { filled: '#7cffa1', dim: '#00ff3222' },
+  failed: { filled: '#ff5566', dim: '#ff556622' },
+  dormant: { filled: '#555', dim: '#333' },
+};
+
+/**
+ * A 4-segment monospace phase indicator showing where a bill sits in the
+ * legislative lifecycle. Reads the phase via `statusToPhase` from explore-config,
+ * which is the single source of truth for status → visual mapping.
+ */
+export default function PhaseGlyph({ status, phase, pulse = false }: Props) {
+  const resolved = phase ?? statusToPhase(status);
+  const colors = TONE_COLORS[resolved.tone];
+  const segments = Array.from({ length: PHASE_GLYPH_SEGMENTS }, (_, i) => i < resolved.segments);
+
+  return (
+    <span
+      role="img"
+      aria-label={`Legislative phase: ${resolved.label}`}
+      title={resolved.label}
+      className="inline-flex items-center gap-[2px] font-mono leading-none select-none"
+    >
+      {segments.map((filled, i) => {
+        const isLastFilled = filled && i === resolved.segments - 1;
+        return (
+          <span
+            key={i}
+            aria-hidden="true"
+            className={
+              pulse && isLastFilled
+                ? 'inline-block w-2 h-2.5 rounded-[1px] animate-pulse'
+                : 'inline-block w-2 h-2.5 rounded-[1px]'
+            }
+            style={{
+              backgroundColor: filled ? colors.filled : colors.dim,
+              boxShadow: filled && resolved.tone !== 'dormant' ? `0 0 4px ${colors.filled}66` : undefined,
+            }}
+          />
+        );
+      })}
+    </span>
+  );
+}

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -17,6 +17,7 @@ import { useAuthHeaders } from '@/hooks/useAuthHeaders';
 const ACCENT = '#00ff32';
 const FEED_LIMIT = 50;
 const STAGGER_COUNT = 5;
+const API_BILL_LIMIT = 5000;
 
 export default function PolicyExploreView() {
   const { session, getHeaders } = useAuthHeaders();
@@ -32,14 +33,21 @@ export default function PolicyExploreView() {
 
   const fetchBills = useCallback(
     async (signal: AbortSignal) => {
-      if (!session?.access_token) return;
+      // Clear loading + cached bills on missing auth so the component can't
+      // get stuck at loading=true if a previous fetch was aborted during an
+      // auth change (the aborted finally block skips setLoading(false)).
+      if (!session?.access_token) {
+        setLoading(false);
+        setAllBills(null);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`${API_BASE}/api/explore/policies?limit=5000`, {
-          signal,
-          headers: getHeaders(),
-        });
+        const res = await fetch(
+          `${API_BASE}/api/explore/policies?limit=${API_BILL_LIMIT}`,
+          { signal, headers: getHeaders() },
+        );
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = (await res.json()) as PolicyBill[];
         setAllBills(data);
@@ -126,7 +134,11 @@ export default function PolicyExploreView() {
   return (
     <div>
       {error && (
-        <div className="mb-4 px-4 py-3 bg-red-900/30 border border-red-800 rounded text-red-300 text-sm">
+        <div
+          role="alert"
+          aria-live="polite"
+          className="mb-4 px-4 py-3 bg-red-900/30 border border-red-800 rounded text-red-300 text-sm"
+        >
           Error loading bills: {error}
         </div>
       )}
@@ -161,8 +173,18 @@ export default function PolicyExploreView() {
             {feedHeader ?? 'activity feed'}
           </div>
           {allBills && (
-            <div className="text-xs font-mono text-gray-600">
-              showing {filteredBills.length} of {matchingBills.length}
+            <div className="text-xs font-mono text-gray-600 flex items-center gap-3">
+              {allBills.length >= API_BILL_LIMIT && (
+                <span
+                  title={`Response hit the ${API_BILL_LIMIT}-bill cap; per-state counts may be incomplete for dormant bills.`}
+                  className="text-amber-400/80"
+                >
+                  showing newest {API_BILL_LIMIT}
+                </span>
+              )}
+              <span>
+                showing {filteredBills.length} of {matchingBills.length}
+              </span>
             </div>
           )}
         </header>

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import StateMap from './StateMap';
+import PolicyFilterPanel, { PolicyFilters } from './PolicyFilterPanel';
+import BillFeedRow from './BillFeedRow';
+import { PolicyBill } from '@/lib/types';
+import {
+  aggregateBillsByState,
+  billAggregateToIndicatorRow,
+  FIPS_TO_ABBREV,
+  formatRelativeDate,
+} from '@/lib/explore-config';
+import { API_BASE } from '@/lib/api';
+import { useAuthHeaders } from '@/hooks/useAuthHeaders';
+
+const ACCENT = '#00ff32';
+const FEED_LIMIT = 50;
+const STAGGER_COUNT = 5;
+
+export default function PolicyExploreView() {
+  const { session, getHeaders } = useAuthHeaders();
+  const [allBills, setAllBills] = useState<PolicyBill[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [filters, setFilters] = useState<PolicyFilters>({
+    stateFips: null,
+    statuses: new Set(),
+    topics: new Set(),
+  });
+
+  const fetchBills = useCallback(
+    async (signal: AbortSignal) => {
+      if (!session?.access_token) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${API_BASE}/api/explore/policies?limit=5000`, {
+          signal,
+          headers: getHeaders(),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as PolicyBill[];
+        setAllBills(data);
+      } catch (e: unknown) {
+        if (signal.aborted) return;
+        setError(e instanceof Error ? e.message : 'Failed to load bills');
+      } finally {
+        if (!signal.aborted) setLoading(false);
+      }
+    },
+    [session?.access_token, getHeaders],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchBills(controller.signal);
+    return () => controller.abort();
+  }, [fetchBills]);
+
+  const stateAggregates = useMemo(
+    () => (allBills ? aggregateBillsByState(allBills) : []),
+    [allBills],
+  );
+
+  const mapIndicators = useMemo(
+    () => stateAggregates.map(billAggregateToIndicatorRow),
+    [stateAggregates],
+  );
+
+  const filteredBills = useMemo(() => {
+    if (!allBills) return [];
+    const stateAbbrev = filters.stateFips ? FIPS_TO_ABBREV[filters.stateFips] : null;
+    const result = allBills.filter((bill) => {
+      if (stateAbbrev && bill.state !== stateAbbrev) return false;
+      if (filters.statuses.size > 0 && !(filters.statuses as Set<string>).has(bill.status)) {
+        return false;
+      }
+      if (filters.topics.size > 0) {
+        if (
+          !bill.topic_tags ||
+          !bill.topic_tags.some((t) => (filters.topics as Set<string>).has(t))
+        ) {
+          return false;
+        }
+      }
+      return true;
+    });
+    result.sort((a, b) => {
+      const av = a.last_action_date ?? '';
+      const bv = b.last_action_date ?? '';
+      return bv.localeCompare(av);
+    });
+    return result.slice(0, FEED_LIMIT);
+  }, [allBills, filters]);
+
+  const stateNameByFips: Record<string, string> = {};
+  for (const agg of stateAggregates) stateNameByFips[agg.fips_code] = agg.state_name;
+
+  const selectedAggregate = filters.stateFips
+    ? stateAggregates.find((s) => s.fips_code === filters.stateFips)
+    : null;
+
+  const feedHeader = selectedAggregate
+    ? `${selectedAggregate.state_name} — ${selectedAggregate.bill_count} bills tracked · last action ${formatRelativeDate(selectedAggregate.last_action_date)}`
+    : null;
+
+  const handleMapSelectState = (fips: string) => {
+    setFilters((prev) => ({
+      ...prev,
+      stateFips: prev.stateFips === fips ? null : fips,
+    }));
+  };
+
+  return (
+    <div>
+      {error && (
+        <div className="mb-4 px-4 py-3 bg-red-900/30 border border-red-800 rounded text-red-300 text-sm">
+          Error loading bills: {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-4 mb-6">
+        <div className="relative">
+          {loading && !allBills ? (
+            <div className="bg-[#1a1a1a] border border-[#404040] rounded-lg p-6 h-80 flex items-center justify-center">
+              <div className="text-gray-500 font-mono text-xs">{'// loading legislative signal...'}</div>
+            </div>
+          ) : (
+            <StateMap
+              indicators={mapIndicators}
+              selectedStateFips={filters.stateFips}
+              onSelectState={handleMapSelectState}
+              accent={ACCENT}
+              colorStart="#222"
+              colorEnd={ACCENT}
+            />
+          )}
+        </div>
+        <PolicyFilterPanel
+          filters={filters}
+          onChange={setFilters}
+          stateNameByFips={stateNameByFips}
+        />
+      </div>
+
+      <section className="bg-[#1a1a1a] border border-[#404040] rounded-lg">
+        <header className="px-5 py-3 border-b border-[#2a2a2a] flex items-center justify-between gap-3 flex-wrap">
+          <div className="text-xs font-mono uppercase tracking-wider text-gray-400">
+            {feedHeader ?? 'activity feed'}
+          </div>
+          {allBills && (
+            <div className="text-xs font-mono text-gray-600">
+              showing {filteredBills.length} of {allBills.length}
+            </div>
+          )}
+        </header>
+
+        <div className="px-5">
+          {!allBills && !loading ? null : filteredBills.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-gray-500 font-mono text-xs">
+                {filters.stateFips || filters.statuses.size || filters.topics.size
+                  ? '// no bills match current filters'
+                  : '// select a state to begin monitoring'}
+              </p>
+            </div>
+          ) : (
+            filteredBills.map((bill, i) => (
+              <BillFeedRow
+                key={`${bill.state}-${bill.bill_number}`}
+                bill={bill}
+                pulse={i === 0}
+                staggerIndex={i < STAGGER_COUNT ? i : undefined}
+              />
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -176,6 +176,7 @@ export default function PolicyExploreView() {
             <div className="text-xs font-mono text-gray-600 flex items-center gap-3">
               {allBills.length >= API_BILL_LIMIT && (
                 <span
+                  aria-label={`Showing newest ${API_BILL_LIMIT} bills. Response hit the ${API_BILL_LIMIT}-bill cap; per-state counts may be incomplete for dormant bills.`}
                   title={`Response hit the ${API_BILL_LIMIT}-bill cap; per-state counts may be incomplete for dormant bills.`}
                   className="text-amber-400/80"
                 >

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -69,7 +69,7 @@ export default function PolicyExploreView() {
     [stateAggregates],
   );
 
-  const filteredBills = useMemo(() => {
+  const matchingBills = useMemo(() => {
     if (!allBills) return [];
     const stateAbbrev = filters.stateFips ? FIPS_TO_ABBREV[filters.stateFips] : null;
     const result = allBills.filter((bill) => {
@@ -92,8 +92,13 @@ export default function PolicyExploreView() {
       const bv = b.last_action_date ?? '';
       return bv.localeCompare(av);
     });
-    return result.slice(0, FEED_LIMIT);
+    return result;
   }, [allBills, filters]);
+
+  const filteredBills = useMemo(
+    () => matchingBills.slice(0, FEED_LIMIT),
+    [matchingBills],
+  );
 
   // Memoized so a stable object reference is passed to PolicyFilterPanel —
   // otherwise the filter rail re-renders on every parent render.
@@ -157,7 +162,7 @@ export default function PolicyExploreView() {
           </div>
           {allBills && (
             <div className="text-xs font-mono text-gray-600">
-              showing {filteredBills.length} of {allBills.length}
+              showing {filteredBills.length} of {matchingBills.length}
             </div>
           )}
         </header>

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -95,8 +95,13 @@ export default function PolicyExploreView() {
     return result.slice(0, FEED_LIMIT);
   }, [allBills, filters]);
 
-  const stateNameByFips: Record<string, string> = {};
-  for (const agg of stateAggregates) stateNameByFips[agg.fips_code] = agg.state_name;
+  // Memoized so a stable object reference is passed to PolicyFilterPanel —
+  // otherwise the filter rail re-renders on every parent render.
+  const stateNameByFips = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const agg of stateAggregates) out[agg.fips_code] = agg.state_name;
+    return out;
+  }, [stateAggregates]);
 
   const selectedAggregate = filters.stateFips
     ? stateAggregates.find((s) => s.fips_code === filters.stateFips)
@@ -158,18 +163,18 @@ export default function PolicyExploreView() {
         </header>
 
         <div className="px-5">
-          {!allBills && !loading ? null : filteredBills.length === 0 ? (
+          {!allBills ? null : filteredBills.length === 0 ? (
             <div className="py-12 text-center">
               <p className="text-gray-500 font-mono text-xs">
                 {filters.stateFips || filters.statuses.size || filters.topics.size
                   ? '// no bills match current filters'
-                  : '// select a state to begin monitoring'}
+                  : '// no bills found'}
               </p>
             </div>
           ) : (
             filteredBills.map((bill, i) => (
               <BillFeedRow
-                key={`${bill.state}-${bill.bill_number}`}
+                key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
                 bill={bill}
                 pulse={i === 0}
                 staggerIndex={i < STAGGER_COUNT ? i : undefined}

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -39,6 +39,7 @@ export default function PolicyExploreView() {
       if (!session?.access_token) {
         setLoading(false);
         setAllBills(null);
+        setError(null);
         return;
       }
       setLoading(true);

--- a/ui-nextjs/components/explore/PolicyFilterPanel.tsx
+++ b/ui-nextjs/components/explore/PolicyFilterPanel.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import {
+  BILL_STATUSES,
+  BillStatus,
+  POLICY_TOPICS,
+  PolicyTopic,
+  statusToPhase,
+} from '@/lib/explore-config';
+import PhaseGlyph from './PhaseGlyph';
+
+export interface PolicyFilters {
+  stateFips: string | null;
+  statuses: Set<BillStatus>;
+  topics: Set<PolicyTopic>;
+}
+
+interface Props {
+  filters: PolicyFilters;
+  onChange: (next: PolicyFilters) => void;
+  /** FIPS → state name, sourced from loaded bills so we only offer real options. */
+  stateNameByFips: Record<string, string>;
+}
+
+const ACCENT = '#00ff32';
+
+function toggleSet<T>(set: Set<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}
+
+export default function PolicyFilterPanel({ filters, onChange, stateNameByFips }: Props) {
+
+  const stateEntries = Object.entries(stateNameByFips).sort(([, a], [, b]) => a.localeCompare(b));
+
+  return (
+    <aside className="bg-[#1a1a1a] border border-[#404040] rounded-lg p-4 space-y-5 text-sm">
+      {/* State selector */}
+      <div>
+        <label
+          htmlFor="policy-state-select"
+          className="block text-xs font-mono uppercase tracking-wider text-gray-500 mb-2"
+        >
+          State
+        </label>
+        <select
+          id="policy-state-select"
+          value={filters.stateFips ?? ''}
+          onChange={(e) => onChange({ ...filters, stateFips: e.target.value || null })}
+          className="w-full bg-[#292929] border border-[#404040] rounded px-2 py-1.5 text-gray-200
+            focus:border-[#00ff32] focus:outline-none"
+        >
+          <option value="">All states</option>
+          {stateEntries.map(([fips, name]) => (
+            <option key={fips} value={fips}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Status chips */}
+      <div>
+        <div className="text-xs font-mono uppercase tracking-wider text-gray-500 mb-2">Status</div>
+        <div className="flex flex-wrap gap-1.5">
+          {BILL_STATUSES.map((status) => {
+            const active = filters.statuses.has(status);
+            const phase = statusToPhase(status);
+            return (
+              <button
+                key={status}
+                type="button"
+                onClick={() =>
+                  onChange({ ...filters, statuses: toggleSet(filters.statuses, status) })
+                }
+                aria-pressed={active}
+                className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-mono
+                  border transition-colors ${
+                    active
+                      ? 'text-black'
+                      : 'bg-[#2a2a2a] text-gray-400 border-[#404040] hover:border-gray-500'
+                  }`}
+                style={
+                  active
+                    ? { backgroundColor: ACCENT, borderColor: ACCENT }
+                    : undefined
+                }
+              >
+                <PhaseGlyph phase={phase} />
+                <span>{status}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Topic chips */}
+      <div>
+        <div className="text-xs font-mono uppercase tracking-wider text-gray-500 mb-2">Topic</div>
+        <div className="flex flex-wrap gap-1.5">
+          {POLICY_TOPICS.map((topic) => {
+            const active = filters.topics.has(topic);
+            return (
+              <button
+                key={topic}
+                type="button"
+                onClick={() => onChange({ ...filters, topics: toggleSet(filters.topics, topic) })}
+                aria-pressed={active}
+                className={`px-2.5 py-1 rounded-full text-xs capitalize border transition-colors ${
+                  active
+                    ? 'text-black'
+                    : 'bg-[#2a2a2a] text-gray-400 border-[#404040] hover:border-gray-500'
+                }`}
+                style={
+                  active
+                    ? { backgroundColor: ACCENT, borderColor: ACCENT }
+                    : undefined
+                }
+              >
+                {topic}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Clear filters — only when any filter is active */}
+      {(filters.stateFips || filters.statuses.size > 0 || filters.topics.size > 0) && (
+        <button
+          type="button"
+          onClick={() =>
+            onChange({ stateFips: null, statuses: new Set(), topics: new Set() })
+          }
+          className="text-xs font-mono text-gray-500 hover:text-[#00ff32] transition-colors"
+        >
+          {'// clear filters'}
+        </button>
+      )}
+    </aside>
+  );
+}

--- a/ui-nextjs/components/explore/PolicyTable.tsx
+++ b/ui-nextjs/components/explore/PolicyTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { PolicyBill } from '@/lib/types';
+import { POLICY_TOPICS } from '@/lib/explore-config';
 
 interface Props {
   bills: PolicyBill[];
@@ -14,16 +15,6 @@ const STATUS_COLORS: Record<string, string> = {
   failed: 'bg-red-900 text-red-300',
   other: 'bg-[#333] text-gray-400',
 };
-
-const ALL_TOPICS = [
-  'housing',
-  'wealth',
-  'education',
-  'criminal justice',
-  'voting rights',
-  'economic development',
-  'health care',
-];
 
 export default function PolicyTable({ bills }: Props) {
   const [activeTopic, setActiveTopic] = useState<string | null>(null);
@@ -46,7 +37,7 @@ export default function PolicyTable({ bills }: Props) {
         >
           All
         </button>
-        {ALL_TOPICS.map((topic) => (
+        {POLICY_TOPICS.map((topic) => (
           <button
             key={topic}
             onClick={() => setActiveTopic(activeTopic === topic ? null : topic)}

--- a/ui-nextjs/lib/explore-config.ts
+++ b/ui-nextjs/lib/explore-config.ts
@@ -1,4 +1,4 @@
-import { ExploreRow, IndicatorRow } from './types';
+import { ExploreRow, IndicatorRow, PolicyBill } from './types';
 
 /** 2-digit FIPS code → 2-letter state abbreviation for API filtering */
 export const FIPS_TO_ABBREV: Record<string, string> = {
@@ -11,6 +11,11 @@ export const FIPS_TO_ABBREV: Record<string, string> = {
   '47': 'TN', '48': 'TX', '49': 'UT', '50': 'VT', '51': 'VA', '53': 'WA', '54': 'WV',
   '55': 'WI', '56': 'WY',
 };
+
+/** 2-letter state abbreviation → 2-digit FIPS code. Inverse of FIPS_TO_ABBREV. */
+export const ABBREV_TO_FIPS: Record<string, string> = Object.fromEntries(
+  Object.entries(FIPS_TO_ABBREV).map(([fips, abbrev]) => [abbrev, fips]),
+);
 
 /** Convert an ExploreRow to the IndicatorRow shape expected by map / chart components. */
 export function toIndicatorRow(r: ExploreRow): IndicatorRow {
@@ -36,6 +41,140 @@ export function collapseToLatestYear(rows: ExploreRow[]): ExploreRow[] {
     if (!prev || row.year > prev.year) byKey.set(key, row);
   }
   return [...byKey.values()];
+}
+
+/** Aggregate bills by state, computing count and the most recent last_action_date per state. */
+export interface StateBillAggregate {
+  state: string;
+  state_name: string;
+  fips_code: string;
+  bill_count: number;
+  last_action_date: string | null;
+}
+
+export function aggregateBillsByState(bills: PolicyBill[]): StateBillAggregate[] {
+  const byAbbrev = new Map<string, StateBillAggregate>();
+  for (const bill of bills) {
+    const fips = ABBREV_TO_FIPS[bill.state];
+    if (!fips) continue; // skip territories / unknown abbrevs
+    const existing = byAbbrev.get(bill.state);
+    if (existing) {
+      existing.bill_count += 1;
+      if (
+        bill.last_action_date &&
+        (!existing.last_action_date || bill.last_action_date > existing.last_action_date)
+      ) {
+        existing.last_action_date = bill.last_action_date;
+      }
+    } else {
+      byAbbrev.set(bill.state, {
+        state: bill.state,
+        state_name: bill.state_name,
+        fips_code: fips,
+        bill_count: 1,
+        last_action_date: bill.last_action_date,
+      });
+    }
+  }
+  return [...byAbbrev.values()];
+}
+
+/** Number of whole days between an ISO date string and now. Returns null for missing input. */
+export function daysSinceLastAction(isoDate: string | null, now: Date = new Date()): number | null {
+  if (!isoDate) return null;
+  const then = new Date(isoDate);
+  if (Number.isNaN(then.getTime())) return null;
+  const msPerDay = 1000 * 60 * 60 * 24;
+  return Math.max(0, Math.floor((now.getTime() - then.getTime()) / msPerDay));
+}
+
+/** Convert a StateBillAggregate into the IndicatorRow shape StateMap consumes.
+ *  The `value` is recency expressed as a "heat score": recent activity = high,
+ *  dormant = low. We invert daysSinceLastAction so that hotter states map to the
+ *  higher end of StateMap's accent gradient. States with no last_action_date get 0.
+ */
+export function billAggregateToIndicatorRow(agg: StateBillAggregate): IndicatorRow {
+  const days = daysSinceLastAction(agg.last_action_date);
+  // Cap at 365 days: anything older than a year looks equally cold.
+  const cappedDays = days == null ? 365 : Math.min(days, 365);
+  const heat = 365 - cappedDays; // 365 = today, 0 = a year+ old or missing
+  return {
+    fips_code: agg.fips_code,
+    geography_name: agg.state_name,
+    state_fips: agg.fips_code,
+    geography_type: 'state',
+    year: new Date().getFullYear(),
+    race: 'total',
+    metric: 'bill_activity_heat',
+    value: heat,
+    margin_of_error: null,
+  };
+}
+
+/** The canonical set of bill statuses emitted by scripts/ingestion/ingest_openstates.py. */
+export const BILL_STATUSES = ['introduced', 'passed', 'signed', 'failed', 'other'] as const;
+export type BillStatus = typeof BILL_STATUSES[number];
+
+/** Topics the ingestion script tags bills with. Shared by PolicyTable and PolicyFilterPanel. */
+export const POLICY_TOPICS = [
+  'housing',
+  'wealth',
+  'education',
+  'criminal justice',
+  'voting rights',
+  'economic development',
+  'health care',
+] as const;
+export type PolicyTopic = typeof POLICY_TOPICS[number];
+
+/** Visual "phase" a bill occupies in the legislative lifecycle, used by PhaseGlyph. */
+export interface BillPhase {
+  /** Number of filled segments out of PHASE_GLYPH_SEGMENTS. */
+  segments: number;
+  /** Visual tone: 'active' for in-progress, 'signed' for law, 'failed' for dead, 'dormant' for unknown. */
+  tone: 'active' | 'signed' | 'failed' | 'dormant';
+  /** Human-readable label for tooltips / aria. */
+  label: string;
+}
+
+export const PHASE_GLYPH_SEGMENTS = 4;
+
+/** Map a bill's raw status string to its visual phase.
+ *
+ *  The ingestion pipeline collapses OpenStates statuses into these five values,
+ *  so this mapping is the single source of truth for how the lifecycle is
+ *  visualized in the Policy Bills tab. Returns a BillPhase with segment count
+ *  and visual tone.
+ */
+export function statusToPhase(status: string | null | undefined): BillPhase {
+  const normalized = (status ?? '').toLowerCase().trim();
+  switch (normalized) {
+    case 'introduced':
+      return { segments: 1, tone: 'active', label: 'introduced' };
+    case 'passed':
+      return { segments: 3, tone: 'active', label: 'passed chamber' };
+    case 'signed':
+      return { segments: 4, tone: 'signed', label: 'signed into law' };
+    case 'failed':
+      return { segments: 1, tone: 'failed', label: 'failed or vetoed' };
+    default:
+      return { segments: 0, tone: 'dormant', label: 'status unknown' };
+  }
+}
+
+/** Humanize a days-ago count into a compact relative string: "2d ago", "3w ago", "march 14". */
+export function formatRelativeDate(isoDate: string | null, now: Date = new Date()): string {
+  const days = daysSinceLastAction(isoDate, now);
+  if (days == null) return 'no recent action';
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.floor(days / 7)}w ago`;
+  // Older than a month: show the actual date in a minimal form.
+  const d = new Date(isoDate as string);
+  return d
+    .toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    .toLowerCase();
 }
 
 export interface DataSourceConfig {
@@ -194,6 +333,22 @@ export const DATA_SOURCES: DataSourceConfig[] = [
     primaryFilterLabel: "Metric",
     description: "State and federal incarceration statistics from the Bureau of Justice Statistics, disaggregated by race and gender.",
     sourceUrl: "https://bjs.ojp.gov/",
+    hasData: true,
+  },
+  // PolicyExploreView renders on this tab; page.tsx short-circuits metric
+  // fetch/layout when key === 'policy', so the metric-shaped fields below
+  // are unused placeholders. Widen DataSourceConfig to a discriminated union
+  // if a second non-metric source lands.
+  {
+    key: "policy",
+    label: "Policy Bills",
+    accent: "#00ff32",
+    endpoint: "/api/explore/policies",
+    hasRace: false,
+    primaryFilterKey: "status",
+    primaryFilterLabel: "Status",
+    description: "State-level legislative bill tracking from OpenStates, with status and topic tags across housing, criminal justice, voting rights, and more.",
+    sourceUrl: "https://openstates.org/",
     hasData: true,
   },
 ];

--- a/ui-nextjs/next.config.ts
+++ b/ui-nextjs/next.config.ts
@@ -3,7 +3,12 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // Enable standalone output for Docker
   output: 'standalone',
-  
+
+  // Use system TLS certificates for font fetching
+  experimental: {
+    turbopackUseSystemTlsCerts: true,
+  },
+
   // Proxy API requests to FastAPI backend
   // Note: WebSocket connections must connect directly to the backend
   // (Next.js rewrites don't support ws:// or wss:// protocols)


### PR DESCRIPTION
## Summary

- Promote Policy Bills from a buried per-state badge to a top-level tab in the explore page's `DataSourceTabs`, matching the design direction in #183. The D4BL founder didn't know the feature existed when shown the tool; this PR makes it discoverable in zero clicks.
- Bills-first layout: recency-colored state map (green hot = recent, dark = dormant) + filter rail (state / status / topic) + activity feed sorted by `last_action_date` DESC with stagger-fade on the first 5 rows.
- Every bill row gets a 4-segment `PhaseGlyph` showing where it sits in the legislative lifecycle (`introduced` / `passed` / `signed` / `failed`), mapped to the exact 5 status values the ingestion pipeline emits.

## What changed

**New components** (`ui-nextjs/components/explore/`)
- `PhaseGlyph.tsx` — 4-segment monospace lifecycle indicator with tone-mapped colors (active green / signed bright / failed red / dormant gray), optional pulse on the last filled segment
- `BillFeedRow.tsx` — one feed row with phase glyph, bill number, topic chips, title, relative last-action timestamp, view link
- `PolicyFilterPanel.tsx` — state selector + status chips (with inline phase glyphs) + topic chips, narrowed types (`Set<BillStatus>`, `Set<PolicyTopic>`)
- `PolicyExploreView.tsx` — owns its own fetch lifecycle, composes `StateMap` + `PolicyFilterPanel` + activity feed

**Modified**
- `ui-nextjs/lib/explore-config.ts` — added `ABBREV_TO_FIPS`, `aggregateBillsByState`, `daysSinceLastAction`, `billAggregateToIndicatorRow`, `formatRelativeDate`, `BILL_STATUSES` / `BillStatus`, `POLICY_TOPICS` / `PolicyTopic`, `statusToPhase` + `PhaseGlyph` types, plus a `policy` entry in `DATA_SOURCES`
- `ui-nextjs/app/explore/page.tsx` — early-return in `fetchData` when `activeSource.key === 'policy'`; branch render to `<PolicyExploreView />` in place of the metric-map layout
- `ui-nextjs/app/globals.css` — `@keyframes billFadeIn` + `.bill-fade-in` utility class + `prefers-reduced-motion` override
- `ui-nextjs/components/explore/PolicyTable.tsx` — import `POLICY_TOPICS` from `explore-config.ts` (dedup with new filter panel)

## Design direction

The tab intentionally defaults to a state view, not a national aggregate — bills are event-shaped data (status + timestamps), not a continuous metric, so a choropleth of raw counts would just reward populous states. The map is recolored by **recency of last bill action** instead. Full design rationale is in #183's body.

## What's explicitly out of scope

- Unifying `PolicyTable.STATUS_COLORS` with `PhaseGlyph.TONE_COLORS` (would change the visual of the existing per-state drawer on other tabs — valid follow-up, not this PR)
- Shared `<FilterChip>` / `<BillRow>` primitive across `PolicyTable` / `PolicyFilterPanel` / `MetricFilterPanel` (same reasoning)
- Server-side aggregation endpoints, URL deep-linking, new font family
- Bill detail pages

## Test plan

- [ ] `npm run lint` in `ui-nextjs/` — clean (0 errors, 1 pre-existing warning unrelated to this PR)
- [ ] `npm run build` in `ui-nextjs/` — `/explore` route compiles
- [ ] Visit `/explore` → click "Policy Bills" tab → bills load, feed shows most recent 50
- [ ] Toggle status chips → feed filters, no re-fetch
- [ ] Toggle topic chips → feed filters
- [ ] Pick a state from the dropdown OR click a state on the map → feed narrows, header updates to show `${State} — ${N} bills tracked · last action Xd ago`
- [ ] Click the same state again → deselects, feed returns to "all states"
- [ ] Switch back to Census / CDC / any other tab → per-state `PolicyBadge` still appears and opens the slide-out drawer as before (no regression)
- [ ] `prefers-reduced-motion` active → stagger-fade animation disabled
- [ ] First row's phase glyph pulses subtly on its last filled segment
- [ ] States with no recent bill activity appear dark on the map; recent states appear bright green

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Policy Bills exploration view with interactive state map, filters, and activity feed
  * Filter panel for state/status/topic selection and a clear-filters action

* **UI**
  * Phase glyphs and bill feed rows with entrance animation, stagger/pulse cues, and reduced-motion support

* **Bug Fixes**
  * Feed shows newest bills first
  * Policy tab hides unrelated error banner and stops unnecessary metric loads

* **Tweaks**
  * Unified topic list across policy views
<!-- end of auto-generated comment: release notes by coderabbit.ai -->