### PR TITLE
fix(explore): improve Policy Bills tab discoverability

### DIFF
--- a/ui-nextjs/components/explore/DataSourceTabs.tsx
+++ b/ui-nextjs/components/explore/DataSourceTabs.tsx
@@ -76,7 +76,7 @@ export default function DataSourceTabs({ activeKey, onSelect }: Props) {
       <div
         ref={scrollerRef}
         tabIndex={-1}
-        className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scroll-smooth outline-none"
+        className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scroll-smooth focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:outline-none"
       >
         {DATA_SOURCES.filter((src) => src.hasData).map((src) => {
           const isActive = src.key === activeKey;

--- a/ui-nextjs/components/explore/DataSourceTabs.tsx
+++ b/ui-nextjs/components/explore/DataSourceTabs.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { DATA_SOURCES, DataSourceConfig } from '@/lib/explore-config';
 
 interface Props {
@@ -7,40 +8,136 @@ interface Props {
   onSelect: (source: DataSourceConfig) => void;
 }
 
+const SCROLL_STEP = 240;
+
 export default function DataSourceTabs({ activeKey, onSelect }: Props) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateOverflow = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 2);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 2);
+  }, []);
+
+  useEffect(() => {
+    updateOverflow();
+    const el = scrollerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(updateOverflow);
+    ro.observe(el);
+    el.addEventListener('scroll', updateOverflow, { passive: true });
+    return () => {
+      ro.disconnect();
+      el.removeEventListener('scroll', updateOverflow);
+    };
+  }, [updateOverflow]);
+
+  const scrollBy = (delta: number) => {
+    scrollerRef.current?.scrollBy({ left: delta, behavior: 'smooth' });
+  };
+
   return (
-    <div className="flex gap-2 overflow-x-auto pb-2 mb-6 scrollbar-thin">
-      {DATA_SOURCES.filter((src) => src.hasData).map((src) => {
-        const isActive = src.key === activeKey;
-        return (
+    <div className="relative mb-6">
+      {canScrollLeft && (
+        <>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute left-0 top-0 bottom-2 w-12 z-10
+                       bg-gradient-to-r from-[#1a1a1a] to-transparent"
+          />
           <button
-            key={src.key}
             type="button"
-            onClick={() => onSelect(src)}
-            className={`
-              relative flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium
-              transition-all duration-200 border
-              ${isActive
-                ? 'text-white border-transparent'
-                : 'text-gray-400 border-[#404040] hover:text-white hover:border-gray-500'
-              }
-            `}
-            style={isActive ? {
-              backgroundColor: `${src.accent}20`,
-              borderColor: src.accent,
-              color: src.accent,
-            } : undefined}
+            aria-label="Scroll tabs left"
+            onClick={() => scrollBy(-SCROLL_STEP)}
+            className="absolute left-0 top-1/2 -translate-y-1/2 z-20
+                       w-8 h-8 rounded-full bg-[#262626] border border-[#404040]
+                       text-gray-300 hover:text-white hover:border-gray-500
+                       flex items-center justify-center
+                       transition-colors shadow-lg shadow-black/40"
           >
-            {src.label}
-            {isActive && (
-              <span
-                className="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-0.5 rounded-full"
-                style={{ backgroundColor: src.accent, boxShadow: `0 0 8px ${src.accent}60` }}
-              />
-            )}
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
           </button>
-        );
-      })}
+        </>
+      )}
+
+      <div
+        ref={scrollerRef}
+        className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scroll-smooth"
+      >
+        {DATA_SOURCES.filter((src) => src.hasData).map((src) => {
+          const isActive = src.key === activeKey;
+          const isPolicy = src.key === 'policy';
+          return (
+            <button
+              key={src.key}
+              type="button"
+              onClick={() => onSelect(src)}
+              className={`
+                relative flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium
+                transition-all duration-200 border
+                ${isActive
+                  ? 'text-white border-transparent'
+                  : 'text-gray-400 border-[#404040] hover:text-white hover:border-gray-500'
+                }
+              `}
+              style={isActive ? {
+                backgroundColor: `${src.accent}20`,
+                borderColor: src.accent,
+                color: src.accent,
+              } : undefined}
+            >
+              {isPolicy && !isActive && (
+                <span className="relative inline-flex mr-2 align-middle" aria-hidden>
+                  <span
+                    className="absolute inline-flex h-2 w-2 rounded-full opacity-60 animate-ping"
+                    style={{ backgroundColor: src.accent }}
+                  />
+                  <span
+                    className="relative inline-flex h-2 w-2 rounded-full"
+                    style={{ backgroundColor: src.accent }}
+                  />
+                </span>
+              )}
+              {src.label}
+              {isActive && (
+                <span
+                  className="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-0.5 rounded-full"
+                  style={{ backgroundColor: src.accent, boxShadow: `0 0 8px ${src.accent}60` }}
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {canScrollRight && (
+        <>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute right-0 top-0 bottom-2 w-12 z-10
+                       bg-gradient-to-l from-[#1a1a1a] to-transparent"
+          />
+          <button
+            type="button"
+            aria-label="Scroll tabs right"
+            onClick={() => scrollBy(SCROLL_STEP)}
+            className="absolute right-0 top-1/2 -translate-y-1/2 z-20
+                       w-8 h-8 rounded-full bg-[#262626] border border-[#404040]
+                       text-gray-300 hover:text-white hover:border-gray-500
+                       flex items-center justify-center
+                       transition-colors shadow-lg shadow-black/40"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/ui-nextjs/components/explore/DataSourceTabs.tsx
+++ b/ui-nextjs/components/explore/DataSourceTabs.tsx
@@ -36,7 +36,15 @@ export default function DataSourceTabs({ activeKey, onSelect }: Props) {
   }, [updateOverflow]);
 
   const scrollBy = (delta: number) => {
-    scrollerRef.current?.scrollBy({ left: delta, behavior: 'smooth' });
+    const el = scrollerRef.current;
+    if (!el) return;
+    // The chevron buttons unmount when scroll limits are reached. If a
+    // keyboard user fires one, move focus to the scroller first so it
+    // isn't silently dropped to document.body when the button disappears.
+    if (document.activeElement && !el.contains(document.activeElement)) {
+      el.focus({ preventScroll: true });
+    }
+    el.scrollBy({ left: delta, behavior: 'smooth' });
   };
 
   return (
@@ -67,15 +75,17 @@ export default function DataSourceTabs({ activeKey, onSelect }: Props) {
 
       <div
         ref={scrollerRef}
-        className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scroll-smooth"
+        tabIndex={-1}
+        className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scroll-smooth outline-none"
       >
         {DATA_SOURCES.filter((src) => src.hasData).map((src) => {
           const isActive = src.key === activeKey;
-          const isPolicy = src.key === 'policy';
+          const isHighlighted = src.highlight === true;
           return (
             <button
               key={src.key}
               type="button"
+              aria-pressed={isActive}
               onClick={() => onSelect(src)}
               className={`
                 relative flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium
@@ -91,7 +101,7 @@ export default function DataSourceTabs({ activeKey, onSelect }: Props) {
                 color: src.accent,
               } : undefined}
             >
-              {isPolicy && !isActive && (
+              {isHighlighted && !isActive && (
                 <span className="relative inline-flex mr-2 align-middle" aria-hidden>
                   <span
                     className="absolute inline-flex h-2 w-2 rounded-full opacity-60 animate-ping"

--- a/ui-nextjs/lib/explore-config.ts
+++ b/ui-nextjs/lib/explore-config.ts
@@ -188,6 +188,9 @@ export interface DataSourceConfig {
   description: string;
   sourceUrl: string;
   hasData: boolean;
+  /** When true, the tab receives a visual elevation treatment (e.g., pulsing
+   *  accent dot) to signal it as a headline or categorically-different source. */
+  highlight?: boolean;
 }
 
 export const DATA_SOURCES: DataSourceConfig[] = [
@@ -218,6 +221,7 @@ export const DATA_SOURCES: DataSourceConfig[] = [
     description: "State-level legislative bill tracking from OpenStates, with status and topic tags across housing, criminal justice, voting rights, and more.",
     sourceUrl: "https://openstates.org/",
     hasData: true,
+    highlight: true,
   },
   {
     key: "cdc",

--- a/ui-nextjs/lib/explore-config.ts
+++ b/ui-nextjs/lib/explore-config.ts
@@ -203,6 +203,22 @@ export const DATA_SOURCES: DataSourceConfig[] = [
     sourceUrl: "https://data.census.gov/",
     hasData: true,
   },
+  // PolicyExploreView renders on this tab; page.tsx short-circuits metric
+  // fetch/layout when key === 'policy', so the metric-shaped fields below
+  // are unused placeholders. Widen DataSourceConfig to a discriminated union
+  // if a second non-metric source lands.
+  {
+    key: "policy",
+    label: "Policy Bills",
+    accent: "#00ff32",
+    endpoint: "/api/explore/policies",
+    hasRace: false,
+    primaryFilterKey: "status",
+    primaryFilterLabel: "Status",
+    description: "State-level legislative bill tracking from OpenStates, with status and topic tags across housing, criminal justice, voting rights, and more.",
+    sourceUrl: "https://openstates.org/",
+    hasData: true,
+  },
   {
     key: "cdc",
     label: "CDC Health",
@@ -333,22 +349,6 @@ export const DATA_SOURCES: DataSourceConfig[] = [
     primaryFilterLabel: "Metric",
     description: "State and federal incarceration statistics from the Bureau of Justice Statistics, disaggregated by race and gender.",
     sourceUrl: "https://bjs.ojp.gov/",
-    hasData: true,
-  },
-  // PolicyExploreView renders on this tab; page.tsx short-circuits metric
-  // fetch/layout when key === 'policy', so the metric-shaped fields below
-  // are unused placeholders. Widen DataSourceConfig to a discriminated union
-  // if a second non-metric source lands.
-  {
-    key: "policy",
-    label: "Policy Bills",
-    accent: "#00ff32",
-    endpoint: "/api/explore/policies",
-    hasRace: false,
-    primaryFilterKey: "status",
-    primaryFilterLabel: "Status",
-    description: "State-level legislative bill tracking from OpenStates, with status and topic tags across housing, criminal justice, voting rights, and more.",
-    sourceUrl: "https://openstates.org/",
     hasData: true,
   },
 ];


### PR DESCRIPTION
## Summary

Policy Bills was surfaced as a top-level data source tab in #184, but it landed at position 12 in a horizontally-scrolling tab row — and on macOS the default invisible scrollbar gave no affordance that more tabs existed beyond the viewport. Users had to scroll blindly to find it.

- **Reorder:** Moved Policy Bills to position 2 (right after Census ACS) so it's visible in the initial viewport on all reasonable widths.
- **Scroll affordance:** Added left/right chevron buttons and edge fade gradients that appear only when the tab row overflows — solves the general overflow discoverability problem, not just Policy Bills.
- **Visual elevation:** Added a pulsing accent dot to the inactive Policy Bills tab to signal that it's a categorically different data type (live legislative tracking) vs. the metric tabs.

## Test plan

- [ ] Load `/explore` at viewport widths where tabs overflow (~1024px and below): chevrons + edge fades appear
- [ ] Load at wide viewport where all tabs fit: no chevrons, no fades
- [ ] Click right chevron: tab row scrolls smoothly by one step
- [ ] Scroll to end: right chevron and right fade disappear; left chevron and left fade appear
- [ ] Policy Bills tab shows a pulsing green dot when any other tab is active
- [ ] Selecting Policy Bills hides the dot (active state takes over)
- [ ] Keyboard tab order still reaches every tab button in list order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Left/right arrow buttons and gradient indicators for horizontal tab scrolling.
  * Smooth programmatic scrolling with keyboard focus preservation and responsive overflow detection for better accessibility and layout behavior.

* **Chores**
  * Reordered data source menu entries and added a new highlight flag to emphasize a specific data source in the menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->