### PR TITLE
feat(explore): policy feed as wire-service dispatch board

### DIFF
--- a/ui-nextjs/components/explore/BillFeedRow.tsx
+++ b/ui-nextjs/components/explore/BillFeedRow.tsx
@@ -8,9 +8,16 @@ interface Props {
   bill: PolicyBill;
   pulse?: boolean;
   staggerIndex?: number;
+  /** When true, the state chip is de-emphasized (user already filtered to this state). */
+  deemphasizeState?: boolean;
 }
 
-export default function BillFeedRow({ bill, pulse = false, staggerIndex }: Props) {
+export default function BillFeedRow({
+  bill,
+  pulse = false,
+  staggerIndex,
+  deemphasizeState = false,
+}: Props) {
   const phase = statusToPhase(bill.status);
   const relativeDate = formatRelativeDate(bill.last_action_date);
   const shouldStagger = staggerIndex != null;
@@ -28,6 +35,16 @@ export default function BillFeedRow({ bill, pulse = false, staggerIndex }: Props
 
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <span
+            title={bill.state_name}
+            className={`px-1.5 py-0.5 rounded text-[10px] font-mono font-bold tracking-wider border ${
+              deemphasizeState
+                ? 'bg-transparent text-gray-500 border-[#333]'
+                : 'bg-[#00ff32]/10 text-[#00ff32] border-[#00ff32]/30'
+            }`}
+          >
+            {bill.state}
+          </span>
           <span className="text-xs font-mono text-gray-500">{bill.bill_number}</span>
           <span
             className="text-[10px] font-mono uppercase tracking-wider text-gray-500"

--- a/ui-nextjs/components/explore/BillFeedRow.tsx
+++ b/ui-nextjs/components/explore/BillFeedRow.tsx
@@ -8,15 +8,15 @@ interface Props {
   bill: PolicyBill;
   pulse?: boolean;
   staggerIndex?: number;
-  /** When true, the state chip is de-emphasized (user already filtered to this state). */
-  deemphasizeState?: boolean;
+  /** Hide the dateline stamp (a grouped section header is already showing the state). */
+  hideDateline?: boolean;
 }
 
 export default function BillFeedRow({
   bill,
   pulse = false,
   staggerIndex,
-  deemphasizeState = false,
+  hideDateline = false,
 }: Props) {
   const phase = statusToPhase(bill.status);
   const relativeDate = formatRelativeDate(bill.last_action_date);
@@ -24,27 +24,39 @@ export default function BillFeedRow({
 
   return (
     <article
-      className={`py-4 border-b border-[#2a2a2a] last:border-b-0 flex items-start gap-4${
+      className={`group py-4 border-b border-[#2a2a2a] last:border-b-0 flex items-start gap-4${
         shouldStagger ? ' bill-fade-in' : ''
       }`}
       style={shouldStagger ? { animationDelay: `${staggerIndex! * 40}ms` } : undefined}
     >
-      <div className="pt-1 shrink-0">
+      {/* DATELINE STAMP — the unmistakable "where this came from" block.
+          Rendered as a small press-stamp with the 2-letter state monogram,
+          a tiny accent tick, and a hairline border. */}
+      {!hideDateline && (
+        <div
+          title={bill.state_name}
+          aria-label={`State: ${bill.state_name}`}
+          className="shrink-0 w-12 flex flex-col items-center gap-1 pt-0.5"
+        >
+          <span
+            aria-hidden="true"
+            className="block h-px w-6 bg-[#00ff32]/40 group-hover:bg-[#00ff32] transition-colors"
+          />
+          <span className="font-mono font-bold text-base tracking-[0.15em] text-gray-200 group-hover:text-[#00ff32] transition-colors">
+            {bill.state}
+          </span>
+          <span className="text-[9px] font-mono uppercase tracking-widest text-gray-600">
+            dateline
+          </span>
+        </div>
+      )}
+
+      <div className="shrink-0 pt-1">
         <PhaseGlyph phase={phase} pulse={pulse} />
       </div>
 
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-1 flex-wrap">
-          <span
-            title={bill.state_name}
-            className={`px-1.5 py-0.5 rounded text-[10px] font-mono font-bold tracking-wider border ${
-              deemphasizeState
-                ? 'bg-transparent text-gray-500 border-[#333]'
-                : 'bg-[#00ff32]/10 text-[#00ff32] border-[#00ff32]/30'
-            }`}
-          >
-            {bill.state}
-          </span>
+        <div className="flex items-center gap-2 mb-1.5 flex-wrap">
           <span className="text-xs font-mono text-gray-500">{bill.bill_number}</span>
           <span
             className="text-[10px] font-mono uppercase tracking-wider text-gray-500"
@@ -75,9 +87,14 @@ export default function BillFeedRow({
           )}
         </div>
 
-        <p className="text-sm text-gray-200 leading-snug mb-1 line-clamp-2">{bill.title}</p>
+        {/* Title — the star of the row. Promoted in size, weight, and color. */}
+        <p className="text-[15px] font-medium text-gray-100 leading-snug mb-1.5 line-clamp-2">
+          {bill.title}
+        </p>
 
-        <p className="text-xs font-mono text-gray-600">last action {relativeDate}</p>
+        <p className="text-[11px] font-mono text-gray-600 uppercase tracking-wider">
+          filed {relativeDate}
+        </p>
       </div>
 
       {bill.url && (
@@ -86,9 +103,9 @@ export default function BillFeedRow({
           target="_blank"
           rel="noopener noreferrer"
           aria-label={`View ${bill.bill_number}: ${bill.title}`}
-          className="shrink-0 self-center text-xs font-mono text-[#00ff32] hover:underline whitespace-nowrap"
+          className="shrink-0 self-center text-[11px] font-mono uppercase tracking-wider text-[#00ff32]/80 hover:text-[#00ff32] whitespace-nowrap border-b border-[#00ff32]/30 hover:border-[#00ff32] pb-0.5 transition-colors"
         >
-          view →
+          dispatch →
         </a>
       )}
     </article>

--- a/ui-nextjs/components/explore/BillFeedRow.tsx
+++ b/ui-nextjs/components/explore/BillFeedRow.tsx
@@ -89,7 +89,7 @@ export default function BillFeedRow({
         </p>
 
         <p className="text-[11px] font-mono text-gray-600 uppercase tracking-wider">
-          filed {relativeDate}
+          last action {relativeDate}
         </p>
       </div>
 

--- a/ui-nextjs/components/explore/BillFeedRow.tsx
+++ b/ui-nextjs/components/explore/BillFeedRow.tsx
@@ -29,9 +29,6 @@ export default function BillFeedRow({
       }`}
       style={shouldStagger ? { animationDelay: `${staggerIndex! * 40}ms` } : undefined}
     >
-      {/* DATELINE STAMP — the unmistakable "where this came from" block.
-          Rendered as a small press-stamp with the 2-letter state monogram,
-          a tiny accent tick, and a hairline border. */}
       {!hideDateline && (
         <div
           title={bill.state_name}
@@ -87,7 +84,6 @@ export default function BillFeedRow({
           )}
         </div>
 
-        {/* Title — the star of the row. Promoted in size, weight, and color. */}
         <p className="text-[15px] font-medium text-gray-100 leading-snug mb-1.5 line-clamp-2">
           {bill.title}
         </p>

--- a/ui-nextjs/components/explore/DataSourceTabs.tsx
+++ b/ui-nextjs/components/explore/DataSourceTabs.tsx
@@ -10,6 +10,41 @@ interface Props {
 
 const SCROLL_STEP = 240;
 
+const CHEVRON_POSITION: Record<'left' | 'right', string> = {
+  left: 'left-0',
+  right: 'right-0',
+};
+const FADE_GRADIENT: Record<'left' | 'right', string> = {
+  left: 'left-0 bg-gradient-to-r',
+  right: 'right-0 bg-gradient-to-l',
+};
+
+function ScrollChevron({ direction, onClick }: { direction: 'left' | 'right'; onClick: () => void }) {
+  const points = direction === 'left' ? '15 18 9 12 15 6' : '9 18 15 12 9 6';
+  return (
+    <>
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute ${FADE_GRADIENT[direction]} top-0 bottom-2 w-12 z-10 from-[#1a1a1a] to-transparent`}
+      />
+      <button
+        type="button"
+        aria-label={`Scroll tabs ${direction}`}
+        onClick={onClick}
+        className={`absolute ${CHEVRON_POSITION[direction]} top-1/2 -translate-y-1/2 z-20
+                   w-8 h-8 rounded-full bg-[#262626] border border-[#404040]
+                   text-gray-300 hover:text-white hover:border-gray-500
+                   flex items-center justify-center
+                   transition-colors shadow-lg shadow-black/40`}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points={points} />
+        </svg>
+      </button>
+    </>
+  );
+}
+
 export default function DataSourceTabs({ activeKey, onSelect }: Props) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -49,29 +84,7 @@ export default function DataSourceTabs({ activeKey, onSelect }: Props) {
 
   return (
     <div className="relative mb-6">
-      {canScrollLeft && (
-        <>
-          <div
-            aria-hidden
-            className="pointer-events-none absolute left-0 top-0 bottom-2 w-12 z-10
-                       bg-gradient-to-r from-[#1a1a1a] to-transparent"
-          />
-          <button
-            type="button"
-            aria-label="Scroll tabs left"
-            onClick={() => scrollBy(-SCROLL_STEP)}
-            className="absolute left-0 top-1/2 -translate-y-1/2 z-20
-                       w-8 h-8 rounded-full bg-[#262626] border border-[#404040]
-                       text-gray-300 hover:text-white hover:border-gray-500
-                       flex items-center justify-center
-                       transition-colors shadow-lg shadow-black/40"
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="15 18 9 12 15 6" />
-            </svg>
-          </button>
-        </>
-      )}
+      {canScrollLeft && <ScrollChevron direction="left" onClick={() => scrollBy(-SCROLL_STEP)} />}
 
       <div
         ref={scrollerRef}
@@ -125,29 +138,7 @@ export default function DataSourceTabs({ activeKey, onSelect }: Props) {
         })}
       </div>
 
-      {canScrollRight && (
-        <>
-          <div
-            aria-hidden
-            className="pointer-events-none absolute right-0 top-0 bottom-2 w-12 z-10
-                       bg-gradient-to-l from-[#1a1a1a] to-transparent"
-          />
-          <button
-            type="button"
-            aria-label="Scroll tabs right"
-            onClick={() => scrollBy(SCROLL_STEP)}
-            className="absolute right-0 top-1/2 -translate-y-1/2 z-20
-                       w-8 h-8 rounded-full bg-[#262626] border border-[#404040]
-                       text-gray-300 hover:text-white hover:border-gray-500
-                       flex items-center justify-center
-                       transition-colors shadow-lg shadow-black/40"
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
-          </button>
-        </>
-      )}
+      {canScrollRight && <ScrollChevron direction="right" onClick={() => scrollBy(SCROLL_STEP)} />}
     </div>
   );
 }

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import StateMap from './StateMap';
 import PolicyFilterPanel, { PolicyFilters } from './PolicyFilterPanel';
 import BillFeedRow from './BillFeedRow';
@@ -31,6 +31,22 @@ export default function PolicyExploreView() {
     topics: new Set(),
   });
   const [searchQuery, setSearchQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Keyboard shortcut: "/" focuses search (skip if already typing in an input).
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      e.preventDefault();
+      searchRef.current?.focus();
+      searchRef.current?.select();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   const fetchBills = useCallback(
     async (signal: AbortSignal) => {
@@ -187,37 +203,59 @@ export default function PolicyExploreView() {
           <div className="text-xs font-mono uppercase tracking-wider text-gray-400">
             {feedHeader ?? 'activity feed'}
           </div>
-          <div className="relative flex-1 min-w-[200px] max-w-sm">
-            <svg
+          <div className="relative flex-1 min-w-[220px] max-w-md group/search">
+            <span
               aria-hidden="true"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500"
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-[#00ff32]/70 font-mono text-xs select-none"
             >
-              <circle cx="11" cy="11" r="7" />
-              <line x1="21" y1="21" x2="16.65" y2="16.65" strokeLinecap="round" />
-            </svg>
+              &gt;
+            </span>
             <input
+              ref={searchRef}
               type="search"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search bills by title, number, or text…"
+              onKeyDown={(e) => {
+                if (e.key === 'Escape' && searchQuery) {
+                  e.preventDefault();
+                  setSearchQuery('');
+                }
+              }}
+              placeholder={
+                allBills
+                  ? `filter ${allBills.length.toLocaleString()} dispatches…`
+                  : 'filter dispatches…'
+              }
               aria-label="Search bills"
-              className="w-full pl-8 pr-8 py-1.5 text-xs font-mono bg-[#0f0f0f] border border-[#2a2a2a] rounded
-                         text-gray-200 placeholder:text-gray-600
-                         focus:outline-none focus:border-[#00ff32]/50 focus:ring-1 focus:ring-[#00ff32]/30"
+              className="w-full pl-7 pr-16 py-1.5 text-xs font-mono bg-[#0f0f0f] border border-[#2a2a2a] rounded
+                         text-gray-100 placeholder:text-gray-600 caret-[#00ff32]
+                         focus:outline-none focus:border-[#00ff32]/60 focus:bg-black"
             />
-            {searchQuery && (
+            {searchQuery ? (
               <button
                 type="button"
-                onClick={() => setSearchQuery('')}
+                onClick={() => {
+                  setSearchQuery('');
+                  searchRef.current?.focus();
+                }}
                 aria-label="Clear search"
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-200 text-xs font-mono"
+                className="absolute right-2 top-1/2 -translate-y-1/2 px-1.5 py-0.5 rounded
+                           text-[10px] font-mono uppercase tracking-wider
+                           text-gray-500 hover:text-[#00ff32] hover:bg-[#00ff32]/10
+                           border border-[#2a2a2a] hover:border-[#00ff32]/50 transition-colors"
               >
-                ×
+                esc
               </button>
+            ) : (
+              <kbd
+                aria-hidden="true"
+                className="absolute right-2 top-1/2 -translate-y-1/2 px-1.5 py-0.5 rounded
+                           text-[10px] font-mono uppercase tracking-wider
+                           text-gray-600 border border-[#2a2a2a]
+                           group-focus-within/search:opacity-0 transition-opacity"
+              >
+                /
+              </kbd>
             )}
           </div>
           {allBills && (
@@ -247,16 +285,66 @@ export default function PolicyExploreView() {
                   : '// no bills found'}
               </p>
             </div>
-          ) : (
+          ) : filters.stateFips ? (
+            // Single-state view: dateline stamp is redundant, hide it.
             filteredBills.map((bill, i) => (
               <BillFeedRow
                 key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
                 bill={bill}
                 pulse={i === 0}
                 staggerIndex={i < STAGGER_COUNT ? i : undefined}
-                deemphasizeState={filters.stateFips !== null}
+                hideDateline
               />
             ))
+          ) : (
+            // Unfiltered view: group consecutive rows by state and show a
+            // sticky dateline banner ABOVE each group. The banner is the
+            // single-source-of-truth for state identity while a group runs.
+            (() => {
+              type Group = { state: string; state_name: string; bills: PolicyBill[] };
+              const groups: Group[] = [];
+              let globalIdx = 0;
+              for (const bill of filteredBills) {
+                const last = groups[groups.length - 1];
+                if (last && last.state === bill.state) {
+                  last.bills.push(bill);
+                } else {
+                  groups.push({ state: bill.state, state_name: bill.state_name, bills: [bill] });
+                }
+              }
+              return groups.map((g) => (
+                <div key={`${g.state}-${globalIdx}`} className="-mx-5">
+                  <h3
+                    className="sticky top-0 z-10 px-5 py-2 bg-[#0f0f0f]/95 backdrop-blur-sm
+                               border-y border-[#00ff32]/20 flex items-center gap-3"
+                  >
+                    <span className="font-mono font-bold text-xs tracking-[0.2em] text-[#00ff32]">
+                      {g.state}
+                    </span>
+                    <span className="text-[10px] font-mono uppercase tracking-widest text-gray-500">
+                      dateline · {g.state_name}
+                    </span>
+                    <span className="ml-auto text-[10px] font-mono text-gray-600">
+                      {g.bills.length} {g.bills.length === 1 ? 'dispatch' : 'dispatches'}
+                    </span>
+                  </h3>
+                  <div className="px-5">
+                    {g.bills.map((bill) => {
+                      const i = globalIdx++;
+                      return (
+                        <BillFeedRow
+                          key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
+                          bill={bill}
+                          pulse={i === 0}
+                          staggerIndex={i < STAGGER_COUNT ? i : undefined}
+                          hideDateline
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              ));
+            })()
           )}
         </div>
       </section>

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -30,6 +30,7 @@ export default function PolicyExploreView() {
     statuses: new Set(),
     topics: new Set(),
   });
+  const [searchQuery, setSearchQuery] = useState('');
 
   const fetchBills = useCallback(
     async (signal: AbortSignal) => {
@@ -81,6 +82,7 @@ export default function PolicyExploreView() {
   const matchingBills = useMemo(() => {
     if (!allBills) return [];
     const stateAbbrev = filters.stateFips ? FIPS_TO_ABBREV[filters.stateFips] : null;
+    const q = searchQuery.trim().toLowerCase();
     const result = allBills.filter((bill) => {
       if (stateAbbrev && bill.state !== stateAbbrev) return false;
       if (filters.statuses.size > 0 && !(filters.statuses as Set<string>).has(bill.status)) {
@@ -94,6 +96,18 @@ export default function PolicyExploreView() {
           return false;
         }
       }
+      if (q) {
+        const haystack = [
+          bill.title,
+          bill.bill_number,
+          bill.summary ?? '',
+          bill.state,
+          bill.state_name,
+        ]
+          .join(' ')
+          .toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
       return true;
     });
     result.sort((a, b) => {
@@ -102,7 +116,7 @@ export default function PolicyExploreView() {
       return bv.localeCompare(av);
     });
     return result;
-  }, [allBills, filters]);
+  }, [allBills, filters, searchQuery]);
 
   const filteredBills = useMemo(
     () => matchingBills.slice(0, FEED_LIMIT),
@@ -173,6 +187,39 @@ export default function PolicyExploreView() {
           <div className="text-xs font-mono uppercase tracking-wider text-gray-400">
             {feedHeader ?? 'activity feed'}
           </div>
+          <div className="relative flex-1 min-w-[200px] max-w-sm">
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" strokeLinecap="round" />
+            </svg>
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search bills by title, number, or text…"
+              aria-label="Search bills"
+              className="w-full pl-8 pr-8 py-1.5 text-xs font-mono bg-[#0f0f0f] border border-[#2a2a2a] rounded
+                         text-gray-200 placeholder:text-gray-600
+                         focus:outline-none focus:border-[#00ff32]/50 focus:ring-1 focus:ring-[#00ff32]/30"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-200 text-xs font-mono"
+              >
+                ×
+              </button>
+            )}
+          </div>
           {allBills && (
             <div className="text-xs font-mono text-gray-600 flex items-center gap-3">
               {allBills.length >= API_BILL_LIMIT && (
@@ -195,7 +242,7 @@ export default function PolicyExploreView() {
           {!allBills ? null : filteredBills.length === 0 ? (
             <div className="py-12 text-center">
               <p className="text-gray-500 font-mono text-xs">
-                {filters.stateFips || filters.statuses.size || filters.topics.size
+                {filters.stateFips || filters.statuses.size || filters.topics.size || searchQuery.trim()
                   ? '// no bills match current filters'
                   : '// no bills found'}
               </p>
@@ -207,6 +254,7 @@ export default function PolicyExploreView() {
                 bill={bill}
                 pulse={i === 0}
                 staggerIndex={i < STAGGER_COUNT ? i : undefined}
+                deemphasizeState={filters.stateFips !== null}
               />
             ))
           )}

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -213,7 +213,7 @@ export default function PolicyExploreView() {
           <div className="relative flex-1 min-w-[220px] max-w-md group/search">
             <span
               aria-hidden="true"
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-[#00ff32]/70 font-mono text-xs select-none"
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-[#00ff32]/70 font-mono text-xs select-none pointer-events-none"
             >
               &gt;
             </span>
@@ -259,7 +259,7 @@ export default function PolicyExploreView() {
                 className="absolute right-2 top-1/2 -translate-y-1/2 px-1.5 py-0.5 rounded
                            text-[10px] font-mono uppercase tracking-wider
                            text-gray-600 border border-[#2a2a2a]
-                           group-focus-within/search:opacity-0 transition-opacity"
+                           group-focus-within/search:opacity-0 transition-opacity pointer-events-none"
               >
                 /
               </kbd>

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -39,7 +39,14 @@ export default function PolicyExploreView() {
       if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      if (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT' ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
       e.preventDefault();
       searchRef.current?.focus();
       searchRef.current?.select();

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -285,66 +285,16 @@ export default function PolicyExploreView() {
                   : '// no bills found'}
               </p>
             </div>
-          ) : filters.stateFips ? (
-            // Single-state view: dateline stamp is redundant, hide it.
+          ) : (
             filteredBills.map((bill, i) => (
               <BillFeedRow
                 key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
                 bill={bill}
                 pulse={i === 0}
                 staggerIndex={i < STAGGER_COUNT ? i : undefined}
-                hideDateline
+                hideDateline={filters.stateFips !== null}
               />
             ))
-          ) : (
-            // Unfiltered view: group consecutive rows by state and show a
-            // sticky dateline banner ABOVE each group. The banner is the
-            // single-source-of-truth for state identity while a group runs.
-            (() => {
-              type Group = { state: string; state_name: string; bills: PolicyBill[] };
-              const groups: Group[] = [];
-              let globalIdx = 0;
-              for (const bill of filteredBills) {
-                const last = groups[groups.length - 1];
-                if (last && last.state === bill.state) {
-                  last.bills.push(bill);
-                } else {
-                  groups.push({ state: bill.state, state_name: bill.state_name, bills: [bill] });
-                }
-              }
-              return groups.map((g) => (
-                <div key={`${g.state}-${globalIdx}`} className="-mx-5">
-                  <h3
-                    className="sticky top-0 z-10 px-5 py-2 bg-[#0f0f0f]/95 backdrop-blur-sm
-                               border-y border-[#00ff32]/20 flex items-center gap-3"
-                  >
-                    <span className="font-mono font-bold text-xs tracking-[0.2em] text-[#00ff32]">
-                      {g.state}
-                    </span>
-                    <span className="text-[10px] font-mono uppercase tracking-widest text-gray-500">
-                      dateline · {g.state_name}
-                    </span>
-                    <span className="ml-auto text-[10px] font-mono text-gray-600">
-                      {g.bills.length} {g.bills.length === 1 ? 'dispatch' : 'dispatches'}
-                    </span>
-                  </h3>
-                  <div className="px-5">
-                    {g.bills.map((bill) => {
-                      const i = globalIdx++;
-                      return (
-                        <BillFeedRow
-                          key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
-                          bill={bill}
-                          pulse={i === 0}
-                          staggerIndex={i < STAGGER_COUNT ? i : undefined}
-                          hideDateline
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              ));
-            })()
           )}
         </div>
       </section>


### PR DESCRIPTION
## Summary

Follow-up to #185 addressing feedback that the bills table was hard to use: (1) no way to tell which state a bill belonged to in the unfiltered view, and (2) no search. Committed to a "legislative wire / political desk" aesthetic that extends the existing terminal phrasing on the explore page.

- **Dateline stamp on every row** — `BillFeedRow` now shows a 2-letter state monogram with an accent tick and "DATELINE" caption to the left of each bill. Hidden when a single state is already selected in the filter panel (redundant there).
- **Command-bar search** — added a search input to the feed header: `>` prompt prefix, placeholder shows live dispatch count (`filter 1,243 dispatches…`), global `/` keyboard shortcut focuses it, `Esc` clears it, `kbd` hints render inline. Filters by title, bill number, summary, state abbrev, and state name.
- **Title promoted as the primary element** — bumped from `text-sm` muted to `text-[15px] font-medium text-gray-100`. Metadata (bill number, phase, filed date) recedes to uppercase mono.
- **Dispatch link** — external link relabeled from "view →" to "dispatch →" with an underlined accent treatment consistent with the wire-service metaphor.
- **ScrollChevron extraction** — pulled the duplicated left/right chevron blocks in `DataSourceTabs` into a single reusable component.

## Test plan

- [ ] Load `/explore` → Policy Bills tab: each row shows a `XX · DATELINE` stamp to the left of the phase glyph
- [ ] Select a state on the map: dateline stamp disappears on each row (redundant)
- [ ] Press `/` anywhere on the page: search input receives focus and selects existing text
- [ ] Type in the search box: feed filters in real time; "showing X of Y" updates
- [ ] Press `Esc` while focused: search clears
- [ ] Click the `esc` pill with search active: clears and refocuses input
- [ ] With no search: `/` hint kbd visible; with focus: hint fades out
- [ ] Tab row still renders identically with scroll chevrons (regression check on #185)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bill search in the feed with `/` keyboard shortcut, Escape to clear, inline hint/button, and client-side filtering.

* **UI Improvements**
  * Refined bill header spacing, typography, and metadata styling.
  * Action link label changed from "view" to "dispatch" with updated hover/underline behavior.
  * Optional timeline/dateline display (auto-hidden when filtering by state).
  * Improved tab scroll controls with clearer edge fades and chevrons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->