### PR TITLE
feat(explore): sortable docket view + wire/docket mode toggle

### DIFF
--- a/ui-nextjs/components/explore/PolicyBillsTable.tsx
+++ b/ui-nextjs/components/explore/PolicyBillsTable.tsx
@@ -38,7 +38,10 @@ function compareBills(a: PolicyBill, b: PolicyBill, key: SortKey): number {
     case 'title':
       return a.title.localeCompare(b.title);
     case 'phase':
-      return statusToPhase(a.status).segments - statusToPhase(b.status).segments;
+      return (
+        statusToPhase(a.status).segments - statusToPhase(b.status).segments ||
+        a.status.localeCompare(b.status)
+      );
     case 'last_action': {
       const av = a.last_action_date ?? '';
       const bv = b.last_action_date ?? '';
@@ -82,19 +85,28 @@ export default function PolicyBillsTable({ bills }: Props) {
                   key={`${col.label}-${idx}`}
                   scope="col"
                   aria-sort={
-                    isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined
+                    isActive
+                      ? sortDir === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : sortable
+                        ? 'none'
+                        : undefined
                   }
-                  onClick={sortable ? () => onSort(col.key!) : undefined}
                   className={`sticky top-0 z-10 bg-[#0f0f0f] border-b border-[#00ff32]/20
                              px-3 py-2.5 text-[10px] font-mono uppercase tracking-[0.18em]
-                             ${sortable ? 'cursor-pointer select-none hover:text-[#00ff32]' : ''}
+                             ${sortable ? 'select-none' : ''}
                              ${isActive ? 'text-[#00ff32]' : 'text-gray-500'}
                              ${col.align === 'right' ? 'text-right' : 'text-left'}
                              ${col.className ?? ''}`}
                 >
-                  <span className="inline-flex items-center gap-1">
-                    {col.label}
-                    {sortable && (
+                  {sortable ? (
+                    <button
+                      type="button"
+                      onClick={() => onSort(col.key!)}
+                      className="inline-flex items-center gap-1 hover:text-[#00ff32] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#00ff32]/60 rounded"
+                    >
+                      {col.label}
                       <span
                         aria-hidden="true"
                         className={`text-[9px] leading-none ${
@@ -103,8 +115,10 @@ export default function PolicyBillsTable({ bills }: Props) {
                       >
                         {isActive ? (sortDir === 'asc' ? '▲' : '▼') : '▾'}
                       </span>
-                    )}
-                  </span>
+                    </button>
+                  ) : (
+                    <span className="inline-flex items-center gap-1">{col.label}</span>
+                  )}
                 </th>
               );
             })}
@@ -155,6 +169,9 @@ export default function PolicyBillsTable({ bills }: Props) {
                           className="px-1.5 py-0.5 rounded border border-[#2a2a2a] text-[10px] text-gray-500"
                         >
                           +{extraTopics}
+                          <span className="sr-only">
+                            {` more topics: ${bill.topic_tags.slice(2).join(', ')}`}
+                          </span>
                         </span>
                       )}
                     </div>

--- a/ui-nextjs/components/explore/PolicyBillsTable.tsx
+++ b/ui-nextjs/components/explore/PolicyBillsTable.tsx
@@ -85,17 +85,11 @@ export default function PolicyBillsTable({ bills }: Props) {
                   key={`${col.label}-${idx}`}
                   scope="col"
                   aria-sort={
-                    isActive
-                      ? sortDir === 'asc'
-                        ? 'ascending'
-                        : 'descending'
-                      : sortable
-                        ? 'none'
-                        : undefined
+                    isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined
                   }
                   className={`sticky top-0 z-10 bg-[#0f0f0f] border-b border-[#00ff32]/20
-                             px-3 py-2.5 text-[10px] font-mono uppercase tracking-[0.18em]
-                             ${sortable ? 'select-none' : ''}
+                             text-[10px] font-mono uppercase tracking-[0.18em]
+                             ${sortable ? 'select-none p-0' : 'px-3 py-2.5'}
                              ${isActive ? 'text-[#00ff32]' : 'text-gray-500'}
                              ${col.align === 'right' ? 'text-right' : 'text-left'}
                              ${col.className ?? ''}`}
@@ -104,7 +98,10 @@ export default function PolicyBillsTable({ bills }: Props) {
                     <button
                       type="button"
                       onClick={() => onSort(col.key!)}
-                      className="inline-flex items-center gap-1 hover:text-[#00ff32] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#00ff32]/60 rounded"
+                      className={`flex w-full items-center gap-1 px-3 py-2.5
+                                  hover:text-[#00ff32] focus:outline-none
+                                  focus-visible:ring-1 focus-visible:ring-[#00ff32]/60 rounded
+                                  ${col.align === 'right' ? 'justify-end' : ''}`}
                     >
                       {col.label}
                       <span

--- a/ui-nextjs/components/explore/PolicyBillsTable.tsx
+++ b/ui-nextjs/components/explore/PolicyBillsTable.tsx
@@ -130,7 +130,7 @@ export default function PolicyBillsTable({ bills }: Props) {
             const extraTopics = (bill.topic_tags?.length ?? 0) - 2;
             return (
               <tr
-                key={bill.url ?? `${bill.state}-${bill.bill_number}`}
+                key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date}`}
                 className="group border-b border-[#1f1f1f] last:border-b-0
                            odd:bg-[#ffffff03] hover:bg-[#00ff3208]
                            transition-colors"

--- a/ui-nextjs/components/explore/PolicyBillsTable.tsx
+++ b/ui-nextjs/components/explore/PolicyBillsTable.tsx
@@ -17,6 +17,7 @@ interface Column {
   label: string;
   className?: string;
   align?: 'left' | 'right';
+  hideLabel?: boolean;
 }
 
 const COLUMNS: Column[] = [
@@ -26,7 +27,7 @@ const COLUMNS: Column[] = [
   { key: 'phase', label: 'phase', className: 'w-32' },
   { key: null, label: 'topics', className: 'w-40' },
   { key: 'last_action', label: 'last action', className: 'w-28', align: 'right' },
-  { key: null, label: 'Open bill', className: 'w-6' },
+  { key: null, label: 'Open bill', className: 'w-6', hideLabel: true },
 ];
 
 function compareBills(a: PolicyBill, b: PolicyBill, key: SortKey): number {
@@ -114,8 +115,8 @@ export default function PolicyBillsTable({ bills }: Props) {
                       </span>
                     </button>
                   ) : (
-                    <span className="inline-flex items-center gap-1">
-                      <span className="sr-only">{col.label}</span>
+                    <span className={`inline-flex items-center gap-1 ${col.hideLabel ? 'sr-only' : ''}`}>
+                      {col.label}
                     </span>
                   )}
                 </th>
@@ -187,7 +188,7 @@ export default function PolicyBillsTable({ bills }: Props) {
                       href={bill.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      aria-label={`View ${bill.bill_number}: ${bill.title}`}
+                      aria-label={`View ${bill.bill_number}: ${bill.title} — opens in a new tab`}
                       className="text-[#00ff32]/60 hover:text-[#00ff32] font-mono text-sm transition-colors"
                     >
                       →

--- a/ui-nextjs/components/explore/PolicyBillsTable.tsx
+++ b/ui-nextjs/components/explore/PolicyBillsTable.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { PolicyBill } from '@/lib/types';
+import { formatRelativeDate, statusToPhase } from '@/lib/explore-config';
+import PhaseGlyph from './PhaseGlyph';
+
+interface Props {
+  bills: PolicyBill[];
+}
+
+type SortKey = 'state' | 'bill_number' | 'title' | 'phase' | 'last_action';
+type SortDir = 'asc' | 'desc';
+
+interface Column {
+  key: SortKey | null;
+  label: string;
+  className?: string;
+  align?: 'left' | 'right';
+}
+
+const COLUMNS: Column[] = [
+  { key: 'state', label: 'state', className: 'w-14' },
+  { key: 'bill_number', label: 'bill no.', className: 'w-28' },
+  { key: 'title', label: 'title' },
+  { key: 'phase', label: 'phase', className: 'w-32' },
+  { key: null, label: 'topics', className: 'w-40' },
+  { key: 'last_action', label: 'last action', className: 'w-28', align: 'right' },
+  { key: null, label: '', className: 'w-6' },
+];
+
+function compareBills(a: PolicyBill, b: PolicyBill, key: SortKey): number {
+  switch (key) {
+    case 'state':
+      return a.state.localeCompare(b.state);
+    case 'bill_number':
+      return a.bill_number.localeCompare(b.bill_number, undefined, { numeric: true });
+    case 'title':
+      return a.title.localeCompare(b.title);
+    case 'phase':
+      return statusToPhase(a.status).segments - statusToPhase(b.status).segments;
+    case 'last_action': {
+      const av = a.last_action_date ?? '';
+      const bv = b.last_action_date ?? '';
+      return av.localeCompare(bv);
+    }
+  }
+}
+
+export default function PolicyBillsTable({ bills }: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>('last_action');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const sorted = useMemo(() => {
+    const copy = [...bills];
+    copy.sort((a, b) => {
+      const cmp = compareBills(a, b, sortKey);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return copy;
+  }, [bills, sortKey, sortDir]);
+
+  const onSort = (key: SortKey | null) => {
+    if (!key) return;
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'last_action' ? 'desc' : 'asc');
+    }
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            {COLUMNS.map((col, idx) => {
+              const isActive = col.key !== null && col.key === sortKey;
+              const sortable = col.key !== null;
+              return (
+                <th
+                  key={`${col.label}-${idx}`}
+                  scope="col"
+                  aria-sort={
+                    isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined
+                  }
+                  onClick={() => onSort(col.key)}
+                  className={`sticky top-0 z-10 bg-[#0f0f0f] border-b border-[#00ff32]/20
+                             px-3 py-2.5 text-[10px] font-mono uppercase tracking-[0.18em]
+                             ${sortable ? 'cursor-pointer select-none hover:text-[#00ff32]' : ''}
+                             ${isActive ? 'text-[#00ff32]' : 'text-gray-500'}
+                             ${col.align === 'right' ? 'text-right' : 'text-left'}
+                             ${col.className ?? ''}`}
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {col.label}
+                    {sortable && (
+                      <span
+                        aria-hidden="true"
+                        className={`text-[9px] leading-none ${
+                          isActive ? 'opacity-100' : 'opacity-30'
+                        }`}
+                      >
+                        {isActive ? (sortDir === 'asc' ? '▲' : '▼') : '▾'}
+                      </span>
+                    )}
+                  </span>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((bill, i) => {
+            const phase = statusToPhase(bill.status);
+            const extraTopics = (bill.topic_tags?.length ?? 0) - 2;
+            return (
+              <tr
+                key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
+                className="group border-b border-[#1f1f1f] last:border-b-0
+                           odd:bg-[#ffffff03] hover:bg-[#00ff3208]
+                           transition-colors"
+              >
+                <td className="pl-3 pr-3 py-2.5 font-mono font-bold text-sm tracking-[0.12em] text-gray-200 group-hover:text-[#00ff32] border-l-2 border-transparent group-hover:border-[#00ff32] transition-colors">
+                  {bill.state}
+                </td>
+                <td className="px-3 py-2.5 font-mono text-xs text-gray-500">
+                  {bill.bill_number}
+                </td>
+                <td className="px-3 py-2.5 text-sm text-gray-100 leading-snug">
+                  <span className="line-clamp-2">{bill.title}</span>
+                </td>
+                <td className="px-3 py-2.5">
+                  <span className="inline-flex items-center gap-2">
+                    <PhaseGlyph phase={phase} />
+                    <span className="text-[11px] font-mono text-gray-500 whitespace-nowrap">
+                      {phase.label}
+                    </span>
+                  </span>
+                </td>
+                <td className="px-3 py-2.5">
+                  {bill.topic_tags && bill.topic_tags.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {bill.topic_tags.slice(0, 2).map((tag) => (
+                        <span
+                          key={tag}
+                          className="px-1.5 py-0.5 rounded bg-[#2a2a2a] text-[10px] text-gray-400 capitalize whitespace-nowrap"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                      {extraTopics > 0 && (
+                        <span
+                          title={bill.topic_tags.slice(2).join(', ')}
+                          className="px-1.5 py-0.5 rounded border border-[#2a2a2a] text-[10px] text-gray-500"
+                        >
+                          +{extraTopics}
+                        </span>
+                      )}
+                    </div>
+                  ) : (
+                    <span className="text-[10px] font-mono text-gray-700">—</span>
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono text-[11px] text-gray-500 whitespace-nowrap">
+                  {formatRelativeDate(bill.last_action_date)}
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  {bill.url ? (
+                    <a
+                      href={bill.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`View ${bill.bill_number}: ${bill.title}`}
+                      className="text-[#00ff32]/60 hover:text-[#00ff32] font-mono text-sm transition-colors"
+                    >
+                      →
+                    </a>
+                  ) : null}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui-nextjs/components/explore/PolicyBillsTable.tsx
+++ b/ui-nextjs/components/explore/PolicyBillsTable.tsx
@@ -60,8 +60,7 @@ export default function PolicyBillsTable({ bills }: Props) {
     return copy;
   }, [bills, sortKey, sortDir]);
 
-  const onSort = (key: SortKey | null) => {
-    if (!key) return;
+  const onSort = (key: SortKey) => {
     if (sortKey === key) {
       setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
     } else {
@@ -76,8 +75,8 @@ export default function PolicyBillsTable({ bills }: Props) {
         <thead>
           <tr>
             {COLUMNS.map((col, idx) => {
-              const isActive = col.key !== null && col.key === sortKey;
               const sortable = col.key !== null;
+              const isActive = sortable && col.key === sortKey;
               return (
                 <th
                   key={`${col.label}-${idx}`}
@@ -85,7 +84,7 @@ export default function PolicyBillsTable({ bills }: Props) {
                   aria-sort={
                     isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined
                   }
-                  onClick={() => onSort(col.key)}
+                  onClick={sortable ? () => onSort(col.key!) : undefined}
                   className={`sticky top-0 z-10 bg-[#0f0f0f] border-b border-[#00ff32]/20
                              px-3 py-2.5 text-[10px] font-mono uppercase tracking-[0.18em]
                              ${sortable ? 'cursor-pointer select-none hover:text-[#00ff32]' : ''}
@@ -112,12 +111,12 @@ export default function PolicyBillsTable({ bills }: Props) {
           </tr>
         </thead>
         <tbody>
-          {sorted.map((bill, i) => {
+          {sorted.map((bill) => {
             const phase = statusToPhase(bill.status);
             const extraTopics = (bill.topic_tags?.length ?? 0) - 2;
             return (
               <tr
-                key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
+                key={bill.url ?? `${bill.state}-${bill.bill_number}`}
                 className="group border-b border-[#1f1f1f] last:border-b-0
                            odd:bg-[#ffffff03] hover:bg-[#00ff3208]
                            transition-colors"

--- a/ui-nextjs/components/explore/PolicyBillsTable.tsx
+++ b/ui-nextjs/components/explore/PolicyBillsTable.tsx
@@ -26,7 +26,7 @@ const COLUMNS: Column[] = [
   { key: 'phase', label: 'phase', className: 'w-32' },
   { key: null, label: 'topics', className: 'w-40' },
   { key: 'last_action', label: 'last action', className: 'w-28', align: 'right' },
-  { key: null, label: '', className: 'w-6' },
+  { key: null, label: 'Open bill', className: 'w-6' },
 ];
 
 function compareBills(a: PolicyBill, b: PolicyBill, key: SortKey): number {
@@ -114,7 +114,9 @@ export default function PolicyBillsTable({ bills }: Props) {
                       </span>
                     </button>
                   ) : (
-                    <span className="inline-flex items-center gap-1">{col.label}</span>
+                    <span className="inline-flex items-center gap-1">
+                      <span className="sr-only">{col.label}</span>
+                    </span>
                   )}
                 </th>
               );

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -19,6 +19,8 @@ const ACCENT = '#00ff32';
 const FEED_LIMIT = 50;
 const STAGGER_COUNT = 5;
 const API_BILL_LIMIT = 5000;
+const VIEW_MODES = ['wire', 'docket'] as const;
+type ViewMode = (typeof VIEW_MODES)[number];
 
 export default function PolicyExploreView() {
   const { session, getHeaders } = useAuthHeaders();
@@ -32,7 +34,7 @@ export default function PolicyExploreView() {
     topics: new Set(),
   });
   const [searchQuery, setSearchQuery] = useState('');
-  const [viewMode, setViewMode] = useState<'wire' | 'docket'>('wire');
+  const [viewMode, setViewMode] = useState<ViewMode>('wire');
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Keyboard shortcut: "/" focuses search (skip if already typing in an input).
@@ -219,7 +221,7 @@ export default function PolicyExploreView() {
             className="inline-flex items-center gap-0 font-mono text-[10px] uppercase tracking-[0.18em]
                        border border-[#2a2a2a] rounded overflow-hidden"
           >
-            {(['wire', 'docket'] as const).map((mode) => {
+            {VIEW_MODES.map((mode) => {
               const isActive = viewMode === mode;
               return (
                 <button
@@ -227,7 +229,17 @@ export default function PolicyExploreView() {
                   type="button"
                   role="radio"
                   aria-checked={isActive}
+                  tabIndex={isActive ? 0 : -1}
                   onClick={() => setViewMode(mode)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                      e.preventDefault();
+                      const next = VIEW_MODES[(VIEW_MODES.indexOf(mode) + 1) % VIEW_MODES.length];
+                      const prev =
+                        VIEW_MODES[(VIEW_MODES.indexOf(mode) - 1 + VIEW_MODES.length) % VIEW_MODES.length];
+                      setViewMode(e.key === 'ArrowRight' ? next : prev);
+                    }
+                  }}
                   className={`px-3 py-1.5 flex items-center gap-1.5 transition-colors ${
                     isActive
                       ? 'bg-[#00ff32]/10 text-[#00ff32]'
@@ -236,14 +248,12 @@ export default function PolicyExploreView() {
                 >
                   <span aria-hidden="true" className="inline-flex items-center">
                     {mode === 'wire' ? (
-                      // three uneven waveform bars → live signal
                       <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
                         <line x1="1" y1="5" x2="1" y2="7" />
                         <line x1="4" y1="2" x2="4" y2="8" />
                         <line x1="7" y1="4" x2="7" y2="7" />
                       </svg>
                     ) : (
-                      // three stacked rules → ledger
                       <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round">
                         <line x1="1" y1="2.5" x2="9" y2="2.5" />
                         <line x1="1" y1="5" x2="9" y2="5" />

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import StateMap from './StateMap';
 import PolicyFilterPanel, { PolicyFilters } from './PolicyFilterPanel';
 import BillFeedRow from './BillFeedRow';
+import PolicyBillsTable from './PolicyBillsTable';
 import { PolicyBill } from '@/lib/types';
 import {
   aggregateBillsByState,
@@ -31,6 +32,7 @@ export default function PolicyExploreView() {
     topics: new Set(),
   });
   const [searchQuery, setSearchQuery] = useState('');
+  const [viewMode, setViewMode] = useState<'wire' | 'docket'>('wire');
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Keyboard shortcut: "/" focuses search (skip if already typing in an input).
@@ -208,7 +210,51 @@ export default function PolicyExploreView() {
       <section className="bg-[#1a1a1a] border border-[#404040] rounded-lg">
         <header className="px-5 py-3 border-b border-[#2a2a2a] flex items-center justify-between gap-3 flex-wrap">
           <div className="text-xs font-mono uppercase tracking-wider text-gray-400">
-            {feedHeader ?? 'activity feed'}
+            {feedHeader ?? (viewMode === 'wire' ? 'activity feed' : 'legislative docket')}
+          </div>
+
+          <div
+            role="radiogroup"
+            aria-label="View mode"
+            className="inline-flex items-center gap-0 font-mono text-[10px] uppercase tracking-[0.18em]
+                       border border-[#2a2a2a] rounded overflow-hidden"
+          >
+            {(['wire', 'docket'] as const).map((mode) => {
+              const isActive = viewMode === mode;
+              return (
+                <button
+                  key={mode}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  onClick={() => setViewMode(mode)}
+                  className={`px-3 py-1.5 flex items-center gap-1.5 transition-colors ${
+                    isActive
+                      ? 'bg-[#00ff32]/10 text-[#00ff32]'
+                      : 'text-gray-500 hover:text-gray-300'
+                  }`}
+                >
+                  <span aria-hidden="true" className="inline-flex items-center">
+                    {mode === 'wire' ? (
+                      // three uneven waveform bars → live signal
+                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                        <line x1="1" y1="5" x2="1" y2="7" />
+                        <line x1="4" y1="2" x2="4" y2="8" />
+                        <line x1="7" y1="4" x2="7" y2="7" />
+                      </svg>
+                    ) : (
+                      // three stacked rules → ledger
+                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round">
+                        <line x1="1" y1="2.5" x2="9" y2="2.5" />
+                        <line x1="1" y1="5" x2="9" y2="5" />
+                        <line x1="1" y1="7.5" x2="9" y2="7.5" />
+                      </svg>
+                    )}
+                  </span>
+                  {mode}
+                </button>
+              );
+            })}
           </div>
           <div className="relative flex-1 min-w-[220px] max-w-md group/search">
             <span
@@ -283,7 +329,7 @@ export default function PolicyExploreView() {
           )}
         </header>
 
-        <div className="px-5">
+        <div className={viewMode === 'wire' ? 'px-5' : ''}>
           {!allBills ? null : filteredBills.length === 0 ? (
             <div className="py-12 text-center">
               <p className="text-gray-500 font-mono text-xs">
@@ -292,7 +338,7 @@ export default function PolicyExploreView() {
                   : '// no bills found'}
               </p>
             </div>
-          ) : (
+          ) : viewMode === 'wire' ? (
             filteredBills.map((bill, i) => (
               <BillFeedRow
                 key={bill.url ?? `${bill.state}-${bill.bill_number}-${bill.introduced_date ?? i}`}
@@ -302,6 +348,8 @@ export default function PolicyExploreView() {
                 hideDateline={filters.stateFips !== null}
               />
             ))
+          ) : (
+            <PolicyBillsTable bills={filteredBills} />
           )}
         </div>
       </section>

--- a/ui-nextjs/components/explore/PolicyExploreView.tsx
+++ b/ui-nextjs/components/explore/PolicyExploreView.tsx
@@ -36,6 +36,7 @@ export default function PolicyExploreView() {
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState<ViewMode>('wire');
   const searchRef = useRef<HTMLInputElement>(null);
+  const viewModeRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   // Keyboard shortcut: "/" focuses search (skip if already typing in an input).
   useEffect(() => {
@@ -221,11 +222,14 @@ export default function PolicyExploreView() {
             className="inline-flex items-center gap-0 font-mono text-[10px] uppercase tracking-[0.18em]
                        border border-[#2a2a2a] rounded overflow-hidden"
           >
-            {VIEW_MODES.map((mode) => {
+            {VIEW_MODES.map((mode, idx) => {
               const isActive = viewMode === mode;
               return (
                 <button
                   key={mode}
+                  ref={(el) => {
+                    viewModeRefs.current[idx] = el;
+                  }}
                   type="button"
                   role="radio"
                   aria-checked={isActive}
@@ -234,10 +238,10 @@ export default function PolicyExploreView() {
                   onKeyDown={(e) => {
                     if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
                       e.preventDefault();
-                      const next = VIEW_MODES[(VIEW_MODES.indexOf(mode) + 1) % VIEW_MODES.length];
-                      const prev =
-                        VIEW_MODES[(VIEW_MODES.indexOf(mode) - 1 + VIEW_MODES.length) % VIEW_MODES.length];
-                      setViewMode(e.key === 'ArrowRight' ? next : prev);
+                      const delta = e.key === 'ArrowRight' ? 1 : -1;
+                      const nextIdx = (idx + delta + VIEW_MODES.length) % VIEW_MODES.length;
+                      setViewMode(VIEW_MODES[nextIdx]);
+                      viewModeRefs.current[nextIdx]?.focus();
                     }
                   }}
                   className={`px-3 py-1.5 flex items-center gap-1.5 transition-colors ${
@@ -333,7 +337,8 @@ export default function PolicyExploreView() {
                 </span>
               )}
               <span>
-                showing {filteredBills.length} of {matchingBills.length}
+                showing {viewMode === 'wire' ? filteredBills.length : matchingBills.length} of{' '}
+                {matchingBills.length}
               </span>
             </div>
           )}
@@ -359,7 +364,7 @@ export default function PolicyExploreView() {
               />
             ))
           ) : (
-            <PolicyBillsTable bills={filteredBills} />
+            <PolicyBillsTable bills={matchingBills} />
           )}
         </div>
       </section>

--- a/ui-nextjs/next.config.ts
+++ b/ui-nextjs/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   // Enable standalone output for Docker
   output: 'standalone',
 
+  // Disable Turbopack for production builds to avoid CSS processing issues
+  turbopack: false,
+
   // Use system TLS certificates for font fetching
   experimental: {
     turbopackUseSystemTlsCerts: true,

--- a/ui-nextjs/next.config.ts
+++ b/ui-nextjs/next.config.ts
@@ -4,9 +4,6 @@ const nextConfig: NextConfig = {
   // Enable standalone output for Docker
   output: 'standalone',
 
-  // Disable Turbopack for production builds to avoid CSS processing issues
-  turbopack: false,
-
   // Use system TLS certificates for font fetching
   experimental: {
     turbopackUseSystemTlsCerts: true,

--- a/ui-nextjs/package.json
+++ b/ui-nextjs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
## Summary

Follow-up to #186 adding a second view for Policy Bills. The existing wire-service feed is optimized for browsing ("what's happening now"); this adds a sortable docket that's optimized for scanning and comparison ("sort by phase and find all signed bills"). Users toggle between them in the section header.

- **New `PolicyBillsTable`** — columns: State, Bill #, Title, Phase, Topics, Last Action, link. Click-to-sort with tri-state direction indicators (`▾` idle → `▲`/`▼` active, accent green). Default sort matches feed (last action desc). `statusToPhase().segments` provides the natural ordinal for phase sort so it sorts by lifecycle progression. Topics beyond the first two collapse into a `+N` badge with the full list in the tooltip. Row hover shows an accent-green "folder tab" bar on the left edge via `border-l-2`. Sticky header, zebra striping, `aria-sort`.
- **Mode toggle in section header** — bordered segmented radiogroup (`WIRE / DOCKET`) with iconographic leading glyph per mode (waveform / stacked rules). Full arrow-key navigation (roving `tabIndex`, ArrowLeft/ArrowRight cycle). Section label swaps between "activity feed" and "legislative docket" based on mode.
- **Shared pipeline** — filter panel, search, `/` keyboard shortcut, and "showing X of Y" count all flow into both views. Switching preserves state.

## Test plan

- [ ] `/explore` → Policy Bills: WIRE / DOCKET toggle visible in the section header
- [ ] Click DOCKET: feed swaps to a sortable table; label changes to "legislative docket"
- [ ] Click each sortable column header: sort cycles asc → desc; active column shows `▲`/`▼` in accent green; others show faded `▾`
- [ ] Non-sortable headers (topics, link) have no hover/cursor treatment and don't respond to clicks
- [ ] Hover a row: left edge gets an accent green bar; state monogram brightens to accent
- [ ] Topics column: rows with >2 topics show `+N` with tooltip listing the rest
- [ ] Focus toggle, press ArrowRight / ArrowLeft: mode cycles
- [ ] Search, state filter, status/topic filters all apply to both views
- [ ] Switching modes preserves the search query and filter state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mode toggle to switch between "activity feed" and "legislative docket" views
  * Introduced a sortable, horizontally scrollable bills table with sticky headers for the docket view
  * Bills show state, bill number, clamped titles, phase glyph + label, relative last-action timestamps, and external links
  * Topics display up to two tags with a “+N” overflow indicator and accessible expanded text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->