### PR TITLE
fix: correct broken GitHub link in /guide Section 5

### DIFF
--- a/ui-nextjs/app/guide/page.tsx
+++ b/ui-nextjs/app/guide/page.tsx
@@ -168,7 +168,7 @@ export default function GuidePage() {
               <span className="text-white font-semibold">Getting started:</span>{' '}
               Read the{' '}
               <a
-                href="https://github.com/dataforblacklives/d4bl-ai-agent"
+                href="https://github.com/William-Hill/d4bl_ai_agent#quick-start-docker-compose--supabase--langfuse"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-[#00ff32] hover:underline"


### PR DESCRIPTION
Closes #193

## Summary
- Section 5 of `/guide` linked to `github.com/dataforblacklives/d4bl-ai-agent`, which 404s
- Swapped to the real repo (`William-Hill/d4bl_ai_agent`) and deep-linked to the README's Quick Start section so new contributors land on setup instructions rather than the repo root

## Test plan
- [x] `npm run lint` — no new warnings
- [x] `npm run build` — /guide route still statically generated
- [ ] Manually verify the link resolves in the deployed `/guide` page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Getting started" link in the "Developing a Feature (Advanced)" section to point to a new resource with a direct link to the Docker Compose + Supabase + Langfuse quick-start guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->