### PR TITLE
feat: document indexing pipeline for staff uploads

### DIFF
--- a/docs/superpowers/plans/2026-04-17-document-indexing-pipeline.md
+++ b/docs/superpowers/plans/2026-04-17-document-indexing-pipeline.md
@@ -1,0 +1,222 @@
+# Plan: Document Indexing Pipeline for Staff Uploads
+
+**Issue:** [#191](https://github.com/William-Hill/d4bl_ai_agent/issues/191)
+**Branch:** `feat/191-document-indexing`
+**Parent context:** v2 work deferred from PR #189 (staff contributor guide)
+
+---
+
+## Goal
+
+When an admin approves a document upload in the review queue, the document is extracted, chunked, embedded, and stored so that (a) CrewAI research agents cite it in answers and (b) it appears in `/explore` vector search results.
+
+## Non-goals (deferred again)
+
+- Data source processing pipeline (that's #190)
+- Example query training integration (that's #192)
+- Retroactive processing of uploads approved before this ships
+- Periodic re-crawl of URL-based documents
+- Multi-format support beyond PDF, DOCX, and URL
+
+---
+
+## Current state
+
+### What exists today
+
+- `uploads` table has a `file_path` column (currently always `NULL` — files aren't persisted)
+- `Upload.metadata_` JSONB stores document-specific fields including `source_url` for URL-based uploads
+- `VectorStore.store_scraped_content()` in `src/d4bl/infra/vector_store.py:104` writes to `scraped_content_vectors` using a required `job_id` FK
+- `scraped_content_vectors` schema (`supabase/migrations/20240101000000_enable_vector_extension.sql:29`) has columns: `id`, `job_id`, `url`, `content`, `content_type`, `metadata`, `embedding`
+- Crawl4AI is wired up for URL fetching via research agents (`src/d4bl/agents/tools/crawl_tools/`)
+- Admin review UI shows `pending_review` → approves → flips `status = approved`. That's where we need to plug in.
+
+### What's missing
+
+- No PDF or DOCX text extractor in the codebase
+- No chunker (existing ingestion scripts embed whole pages, not chunks — the scraped_content_vectors schema assumes ≤ 6000 chars per row, enforced by VectorStore truncation)
+- No background task runner for inline Python work (only CrewAI jobs use `research_runner.py`)
+- `scraped_content_vectors.job_id` is `NOT NULL` — incompatible with documents that don't belong to a research job
+
+---
+
+## Design decisions (need review before implementation)
+
+### 1. Where do embedded chunks live?
+
+**Option A (recommended):** Extend `scraped_content_vectors` — make `job_id` nullable, add a `source` column (`research_job` | `staff_upload`).
+
+**Option B:** New table `staff_document_vectors` with its own schema.
+
+**Why A:** Research agents already query `scraped_content_vectors` — making staff docs appear in the same table means zero agent-side changes. Adding a `source` column lets `/explore` filter to just staff-contributed content when desired.
+
+**Why not B:** Means duplicating the embedding column, index, and query logic. Every consumer has to be taught about two tables.
+
+**Tradeoff:** Schema change affects the research pipeline. We'd need a small migration and a careful review of existing inserts (all use `job_id`).
+
+### 2. Processing trigger
+
+**Option A (recommended):** Inline on approval — admin clicks approve, processing runs in the request, admin sees success or error immediately.
+
+**Option B:** Background task via FastAPI `BackgroundTasks` — admin click returns fast, processing runs after.
+
+**Option C:** Separate worker process (Celery, RQ) — most robust, most infra.
+
+**Why A:** Simplest. The review queue is an admin-only surface, and admins don't mind a few seconds of wait for explicit feedback. PDF extraction + chunking + embedding for a typical 20-page doc is ~10–30 seconds on local Ollama. Inline also lets us surface errors without a separate status-polling UI.
+
+**Why not B/C:** Worth it for large docs (100+ pages), but we can add an async path later. Start simple.
+
+**Failure mode:** On timeout or extraction error, flip status to `processing_failed` and show the error in the review queue. Admin can fix metadata and click "retry" (new endpoint).
+
+### 3. Raw file storage
+
+**Option A (recommended):** Parse-and-discard. Extract text on approval, store chunks in the vector table, drop the original upload bytes.
+
+**Option B:** Persist raw file to Supabase Storage so citations can deep-link back to the original PDF.
+
+**Why A:** PR #189 explicitly deferred Supabase Storage wiring. Shipping without it keeps the scope tight. Citations can still identify the source (filename, uploader, upload date) via metadata.
+
+**Why not B:** Worth revisiting when we have a concrete user story for "open the original PDF" — today no UI shows raw files.
+
+**Tradeoff:** If extraction fails and we've discarded the file, the admin can't retry without re-uploading. Mitigation: do extraction in the upload endpoint, not on approval — reject bad files at upload time.
+
+### 4. URL-based documents
+
+**Option A (recommended):** Fetch via Crawl4AI on approval (same time as PDF extraction).
+
+**Option B:** Fetch on upload; store extracted text in `metadata_.preview` so admins can review the actual content, not just the URL.
+
+**Why B actually wins:** Admins should be approving the content, not the URL. If the site changed between upload and approval, they'd be approving something they never saw. Fetching on upload + storing preview in metadata lets the review be honest.
+
+**Cost:** Upload endpoint gets slower (Crawl4AI fetch is 2–10s). Acceptable for staff workflow.
+
+**Correction to issue description:** I'm flipping my recommendation on this one compared to the issue — crawl on upload, not approval.
+
+### 5. Chunking strategy
+
+**Option A (recommended):** Simple paragraph-based chunking with 500-char target and 100-char overlap. No fancy sentence boundary detection.
+
+**Option B:** LangChain / LlamaIndex recursive chunker.
+
+**Why A:** mxbai-embed-large handles chunks up to 6000 chars (already truncated in vector_store.py:65). Paragraph splits are good enough for agent retrieval and avoid a heavy dependency.
+
+### 6. Agent citation format
+
+When an agent cites a chunk, it needs to identify the source clearly. Proposed `metadata` JSONB shape for staff-upload rows:
+
+```json
+{
+  "source_type": "staff_upload",
+  "upload_id": "uuid",
+  "uploader_email": "alice@d4bl.org",
+  "title": "Overlooked: Women and Jails",
+  "original_filename": "vera_overlooked.pdf",
+  "source_url": null,
+  "chunk_index": 3,
+  "total_chunks": 47,
+  "uploaded_at": "2026-04-17T15:00:00Z"
+}
+```
+
+Agents can include `"Source: <title> (staff upload by <email>)"` in citations.
+
+---
+
+## Implementation milestones
+
+### Milestone 1: Schema + extractors (foundational)
+
+- [ ] Migration: `supabase/migrations/20260418000000_staff_documents_vectors.sql` — `ALTER TABLE scraped_content_vectors ALTER COLUMN job_id DROP NOT NULL; ADD COLUMN source VARCHAR(30) NOT NULL DEFAULT 'research_job';`
+- [ ] `src/d4bl/services/document_processing/extractors.py` — `extract_pdf(bytes) -> str`, `extract_docx(bytes) -> str`, `extract_url(url) -> str` (uses Crawl4AI)
+- [ ] `src/d4bl/services/document_processing/chunker.py` — `chunk_text(text, chunk_size=500, overlap=100) -> list[str]`
+- [ ] Unit tests for extractors and chunker (fixtures: small PDF, small DOCX)
+
+### Milestone 2: Vector store extension
+
+- [ ] `VectorStore.store_staff_document(upload_id, chunks, metadata) -> list[UUID]` — embed each chunk, insert with `job_id=NULL`, `source='staff_upload'`
+- [ ] Update `store_scraped_content` to default `source='research_job'` explicitly
+- [ ] Integration test: insert chunks, query by metadata, verify retrieval
+
+### Milestone 3: Upload endpoint — fetch URL previews
+
+- [ ] Modify `POST /api/admin/uploads/document` in `src/d4bl/app/upload_routes.py` — when `url` is provided, fetch via Crawl4AI and store extracted text in `metadata_.preview_text`
+- [ ] On fetch failure, reject with 422 + error message
+- [ ] Test: mock Crawl4AI, confirm preview is populated
+
+### Milestone 4: Approval processing
+
+- [ ] `src/d4bl/services/document_processing/approve.py` — `process_document_upload(upload_id, db) -> None` that reads metadata, extracts + chunks + embeds + stores
+- [ ] Modify `POST /api/admin/uploads/{upload_id}/review` — when `status = approved` and `upload_type = document`, call `process_document_upload` inline
+- [ ] On exception, set `upload.status = processing_failed`, store error in `reviewer_notes`, do not raise (admin can retry)
+- [ ] New endpoint: `POST /api/admin/uploads/{upload_id}/retry-processing` (admin-only)
+
+### Milestone 5: UI surfacing
+
+- [ ] `ReviewQueue.tsx` — show `processing_failed` state with error message + retry button
+- [ ] `UploadHistory.tsx` — show processing status for document uploads (pending / approved / indexed / processing_failed)
+- [ ] `/explore` vector search — no code change if we're reusing `scraped_content_vectors`, but add a filter UI for "Staff uploads only" (optional — can defer)
+
+### Milestone 6: Guide copy fix
+
+- [ ] Update `ui-nextjs/app/guide/page.tsx` Section 2 to describe actual shipped behavior
+- [ ] Specifically: "When you upload, the platform fetches URL content immediately so the admin can review the actual text. On approval, the document is chunked and indexed into the vector store. Agents cite approved documents in research answers."
+
+### Milestone 7: Verification + tests
+
+- [ ] End-to-end test: upload PDF → admin approves → vector search retrieves a chunk
+- [ ] End-to-end test: upload URL → preview populates → admin approves → agent citation includes title
+- [ ] Manual QA: run a research job, confirm an approved staff document surfaces in the output
+
+---
+
+## Critical files
+
+| Path | Role |
+| --- | --- |
+| `src/d4bl/app/upload_routes.py` | Add preview fetch on upload, call processing on review |
+| `src/d4bl/infra/vector_store.py` | Add `store_staff_document` method |
+| `src/d4bl/services/document_processing/` | **New package** for extractors, chunker, approve flow |
+| `src/d4bl/infra/database.py` | No model changes — schema change via migration only |
+| `supabase/migrations/20260418000000_*.sql` | **New** — relax job_id, add source column |
+| `ui-nextjs/components/admin/ReviewQueue.tsx` | Surface processing state + retry |
+| `ui-nextjs/components/admin/UploadHistory.tsx` | Show indexed/failed state |
+| `ui-nextjs/app/guide/page.tsx` | Section 2 copy fix |
+| `tests/test_document_processing.py` | **New** — extractor + chunker + approve tests |
+
+---
+
+## Dependencies to add
+
+- `pypdf` (PDF text extraction) — lightweight, already in the Python ecosystem, no native deps
+- `python-docx` (DOCX text extraction) — similar profile
+
+Both added to `pyproject.toml` under `[project.optional-dependencies.ingestion]` or the default deps (decide during Milestone 1).
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Schema change breaks existing research_job inserts | High | Default `source = 'research_job'`, update `store_scraped_content` explicitly, add migration test |
+| Crawl4AI unavailable during upload | Medium | 422 with actionable error; admin can retry upload |
+| Ollama embedding slow on large docs (100+ chunks) | Medium | Accept for inline path; document in PR that >50-page docs may take 1min+ |
+| PDF extraction fails on scanned/image-based PDFs | Low | pypdf returns empty string; upload endpoint rejects with clear message |
+
+---
+
+## Out of scope for this PR
+
+- Supabase Storage for raw file persistence
+- Re-crawl of URL documents on a schedule
+- OCR for image-based PDFs
+- Background worker / queue system for long-running processing
+- Retroactive processing of pre-existing approved uploads (none exist yet)
+
+---
+
+## Questions for review
+
+1. Do you agree with flipping URL fetch from approval-time to upload-time (design decision #4)?
+2. Are you comfortable with inline processing for v1 (design decision #2), or should we plan for a background worker up front?
+3. Should the schema change (design decision #1) be a separate PR that lands first, or bundled into this feature PR?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "APScheduler>=3.10,<4",
     "trafilatura>=1.6",
     "pypdf>=4.0",
+    "python-docx>=1.1",
 ]
 
 [project.scripts]
@@ -29,6 +30,7 @@ test = [
     "pytest-asyncio>=0.23",
     "httpx>=0.27",
     "psycopg2-binary>=2.9",
+    "reportlab>=4.0",
 ]
 
 [build-system]

--- a/src/d4bl/app/upload_routes.py
+++ b/src/d4bl/app/upload_routes.py
@@ -6,6 +6,7 @@ and feature requests. Includes admin review workflow.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
 from uuid import UUID, uuid4
@@ -30,6 +31,10 @@ from d4bl.infra.database import (
     Upload,
     get_db,
 )
+from d4bl.services.document_processing.extractors import (
+    ExtractionError,
+    extract_url,
+)
 
 router = APIRouter(tags=["uploads"])
 
@@ -37,6 +42,7 @@ MAX_DATASOURCE_SIZE = 50 * 1024 * 1024  # 50 MB
 MAX_DOCUMENT_SIZE = 25 * 1024 * 1024  # 25 MB
 ALLOWED_DATASOURCE_EXT = {".csv", ".xlsx"}
 ALLOWED_DOCUMENT_EXT = {".pdf", ".docx"}
+MAX_PREVIEW_CHARS = 5000
 
 
 def _safe_filename(raw: str | None) -> str:
@@ -158,6 +164,7 @@ async def upload_document(
     upload_id = uuid4()
     file_size = None
     filename = None
+    preview_text = None
 
     if file:
         ext = _file_ext(file.filename)
@@ -171,6 +178,15 @@ async def upload_document(
             raise HTTPException(400, "File is empty")
         file_size = len(content)
         filename = _safe_filename(file.filename)
+    elif validated.url:
+        # Fetch the URL on submit so the admin reviews the actual text,
+        # not just a link — the linked page could change between
+        # submission and approval.
+        try:
+            full_text = await asyncio.to_thread(extract_url, validated.url)
+        except ExtractionError as exc:
+            raise HTTPException(422, f"Could not extract content from URL: {exc}") from exc
+        preview_text = full_text[:MAX_PREVIEW_CHARS]
 
     upload = Upload(
         id=upload_id,
@@ -185,6 +201,7 @@ async def upload_document(
             "document_type": validated.document_type,
             "topic_tags": validated.topic_tags,
             "url": validated.url,
+            "preview_text": preview_text,
         },
     )
     db.add(upload)

--- a/src/d4bl/app/upload_routes.py
+++ b/src/d4bl/app/upload_routes.py
@@ -470,7 +470,7 @@ async def review_upload(
             reviewed_at=now,
         )
         await db.commit()
-        logger.warning("Document upload %s processing failed: %s", upload_id, exc)
+        logger.exception("Document upload %s processing failed", upload_id)
         return {
             "id": str(upload_id),
             "status": "processing_failed",
@@ -497,7 +497,10 @@ async def retry_upload_processing(
 ):
     """Retry processing for a document upload in ``processing_failed`` state."""
     result = await db.execute(
-        text("SELECT id, status, upload_type FROM uploads WHERE id = CAST(:uid AS uuid)"),
+        text(
+            "SELECT id, status, upload_type, reviewer_notes "
+            "FROM uploads WHERE id = CAST(:uid AS uuid)"
+        ),
         {"uid": str(upload_id)},
     )
     row = result.mappings().first()
@@ -509,14 +512,17 @@ async def retry_upload_processing(
         raise HTTPException(400, f"Upload is {row['status']}, not processing_failed")
 
     now = datetime.now(timezone.utc)
+    existing_notes = row["reviewer_notes"]
     try:
         await process_document_upload(db, upload_id)
     except Exception as exc:  # noqa: BLE001
+        retry_note = f"Retry failed: {exc}"
+        notes = f"{existing_notes}\n\n{retry_note}" if existing_notes else retry_note
         await _set_upload_status(
             db, upload_id,
             status="processing_failed",
             reviewer_id=user.id,
-            notes=f"Retry failed: {exc}",
+            notes=notes,
             reviewed_at=now,
         )
         await db.commit()
@@ -530,7 +536,7 @@ async def retry_upload_processing(
         db, upload_id,
         status="indexed",
         reviewer_id=user.id,
-        notes=None,
+        notes=existing_notes,  # preserve original approval notes
         reviewed_at=now,
     )
     await db.commit()

--- a/src/d4bl/app/upload_routes.py
+++ b/src/d4bl/app/upload_routes.py
@@ -7,6 +7,7 @@ and feature requests. Includes admin review workflow.
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
 from uuid import UUID, uuid4
@@ -31,8 +32,11 @@ from d4bl.infra.database import (
     Upload,
     get_db,
 )
+from d4bl.services.document_processing.approve import process_document_upload
 from d4bl.services.document_processing.extractors import (
     ExtractionError,
+    extract_docx,
+    extract_pdf,
     extract_url,
 )
 
@@ -43,6 +47,9 @@ MAX_DOCUMENT_SIZE = 25 * 1024 * 1024  # 25 MB
 ALLOWED_DATASOURCE_EXT = {".csv", ".xlsx"}
 ALLOWED_DOCUMENT_EXT = {".pdf", ".docx"}
 MAX_PREVIEW_CHARS = 5000
+MAX_FULL_TEXT_CHARS = 500_000
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_filename(raw: str | None) -> str:
@@ -164,13 +171,12 @@ async def upload_document(
     upload_id = uuid4()
     file_size = None
     filename = None
-    preview_text = None
+    full_text: str | None = None
 
     if file:
         ext = _file_ext(file.filename)
         if ext not in ALLOWED_DOCUMENT_EXT:
             raise HTTPException(400, f"File type {ext!r} not allowed. Use: {ALLOWED_DOCUMENT_EXT}")
-        # File bytes are read for validation only; Supabase Storage upload is deferred.
         content = await file.read()
         if len(content) > MAX_DOCUMENT_SIZE:
             raise HTTPException(400, f"File too large. Max {MAX_DOCUMENT_SIZE // (1024 * 1024)}MB")
@@ -178,6 +184,13 @@ async def upload_document(
             raise HTTPException(400, "File is empty")
         file_size = len(content)
         filename = _safe_filename(file.filename)
+        # Extract text at submit so approval processing can chunk + embed
+        # without needing the raw file back (Supabase Storage is deferred).
+        try:
+            extractor = extract_pdf if ext == ".pdf" else extract_docx
+            full_text = await asyncio.to_thread(extractor, content)
+        except ExtractionError as exc:
+            raise HTTPException(422, f"Could not extract content from file: {exc}") from exc
     elif validated.url:
         # Fetch the URL on submit so the admin reviews the actual text,
         # not just a link — the linked page could change between
@@ -186,7 +199,9 @@ async def upload_document(
             full_text = await asyncio.to_thread(extract_url, validated.url)
         except ExtractionError as exc:
             raise HTTPException(422, f"Could not extract content from URL: {exc}") from exc
-        preview_text = full_text[:MAX_PREVIEW_CHARS]
+
+    preview_text = full_text[:MAX_PREVIEW_CHARS] if full_text else None
+    stored_full_text = full_text[:MAX_FULL_TEXT_CHARS] if full_text else None
 
     upload = Upload(
         id=upload_id,
@@ -202,6 +217,7 @@ async def upload_document(
             "topic_tags": validated.topic_tags,
             "url": validated.url,
             "preview_text": preview_text,
+            "full_text": stored_full_text,
         },
     )
     db.add(upload)
@@ -281,7 +297,10 @@ async def submit_feature_request(
 
 
 VALID_UPLOAD_TYPES = {"datasource", "document", "query", "feature_request"}
-VALID_UPLOAD_STATUSES = {"pending_review", "approved", "rejected", "processing", "live"}
+VALID_UPLOAD_STATUSES = {
+    "pending_review", "approved", "rejected", "processing", "live",
+    "indexed", "processing_failed",
+}
 
 
 @router.get("/api/admin/uploads")
@@ -356,6 +375,38 @@ async def list_uploads(
     ]
 
 
+async def _set_upload_status(
+    db: AsyncSession,
+    upload_id: UUID,
+    *,
+    status: str,
+    reviewer_id: UUID | None,
+    notes: str | None,
+    reviewed_at: datetime | None,
+) -> None:
+    """Update an upload's status and review metadata."""
+    now = datetime.now(timezone.utc)
+    await db.execute(
+        text("""
+            UPDATE uploads
+            SET status = :status,
+                reviewer_id = CAST(:reviewer_id AS uuid),
+                reviewer_notes = :notes,
+                reviewed_at = :reviewed_at,
+                updated_at = :updated_at
+            WHERE id = CAST(:uid AS uuid)
+        """),
+        {
+            "status": status,
+            "reviewer_id": str(reviewer_id) if reviewer_id else None,
+            "notes": notes,
+            "reviewed_at": reviewed_at,
+            "updated_at": now,
+            "uid": str(upload_id),
+        },
+    )
+
+
 @router.patch("/api/admin/uploads/{upload_id}/review")
 async def review_upload(
     upload_id: UUID,
@@ -363,9 +414,16 @@ async def review_upload(
     user: CurrentUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Approve or reject an upload (admin only)."""
+    """Approve or reject an upload (admin only).
+
+    Approving a ``document`` upload also triggers inline processing —
+    extract text is chunked, embedded, and written to the vector store.
+    On failure the upload is marked ``processing_failed`` and the error
+    is stored in ``reviewer_notes``; the admin can retry via
+    ``POST /api/admin/uploads/{upload_id}/retry-processing``.
+    """
     result = await db.execute(
-        text("SELECT id, status FROM uploads WHERE id = CAST(:uid AS uuid)"),
+        text("SELECT id, status, upload_type FROM uploads WHERE id = CAST(:uid AS uuid)"),
         {"uid": str(upload_id)},
     )
     row = result.mappings().first()
@@ -374,26 +432,106 @@ async def review_upload(
     if row["status"] != "pending_review":
         raise HTTPException(400, f"Upload is already {row['status']}")
 
-    new_status = "approved" if body.action == "approve" else "rejected"
     now = datetime.now(timezone.utc)
 
-    await db.execute(
-        text("""
-            UPDATE uploads
-            SET status = :status, reviewer_id = CAST(:reviewer_id AS uuid),
-                reviewer_notes = :notes, reviewed_at = :reviewed_at,
-                updated_at = :updated_at
-            WHERE id = CAST(:uid AS uuid)
-        """),
-        {
-            "status": new_status,
-            "reviewer_id": str(user.id),
-            "notes": body.notes,
-            "reviewed_at": now,
-            "updated_at": now,
-            "uid": str(upload_id),
-        },
+    if body.action == "reject":
+        await _set_upload_status(
+            db, upload_id,
+            status="rejected",
+            reviewer_id=user.id,
+            notes=body.notes,
+            reviewed_at=now,
+        )
+        await db.commit()
+        return {"id": str(upload_id), "status": "rejected", "reviewed_at": now.isoformat()}
+
+    if row["upload_type"] != "document":
+        await _set_upload_status(
+            db, upload_id,
+            status="approved",
+            reviewer_id=user.id,
+            notes=body.notes,
+            reviewed_at=now,
+        )
+        await db.commit()
+        return {"id": str(upload_id), "status": "approved", "reviewed_at": now.isoformat()}
+
+    try:
+        await process_document_upload(db, upload_id)
+    except Exception as exc:  # noqa: BLE001 — any processing failure is admin-visible
+        error_note = f"Processing failed: {exc}"
+        if body.notes:
+            error_note = f"{body.notes}\n\n{error_note}"
+        await _set_upload_status(
+            db, upload_id,
+            status="processing_failed",
+            reviewer_id=user.id,
+            notes=error_note,
+            reviewed_at=now,
+        )
+        await db.commit()
+        logger.warning("Document upload %s processing failed: %s", upload_id, exc)
+        return {
+            "id": str(upload_id),
+            "status": "processing_failed",
+            "reviewed_at": now.isoformat(),
+            "error": str(exc),
+        }
+
+    await _set_upload_status(
+        db, upload_id,
+        status="indexed",
+        reviewer_id=user.id,
+        notes=body.notes,
+        reviewed_at=now,
     )
     await db.commit()
+    return {"id": str(upload_id), "status": "indexed", "reviewed_at": now.isoformat()}
 
-    return {"id": str(upload_id), "status": new_status, "reviewed_at": now.isoformat()}
+
+@router.post("/api/admin/uploads/{upload_id}/retry-processing")
+async def retry_upload_processing(
+    upload_id: UUID,
+    user: CurrentUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Retry processing for a document upload in ``processing_failed`` state."""
+    result = await db.execute(
+        text("SELECT id, status, upload_type FROM uploads WHERE id = CAST(:uid AS uuid)"),
+        {"uid": str(upload_id)},
+    )
+    row = result.mappings().first()
+    if not row:
+        raise HTTPException(404, "Upload not found")
+    if row["upload_type"] != "document":
+        raise HTTPException(400, "Only document uploads can be retried")
+    if row["status"] != "processing_failed":
+        raise HTTPException(400, f"Upload is {row['status']}, not processing_failed")
+
+    now = datetime.now(timezone.utc)
+    try:
+        await process_document_upload(db, upload_id)
+    except Exception as exc:  # noqa: BLE001
+        await _set_upload_status(
+            db, upload_id,
+            status="processing_failed",
+            reviewer_id=user.id,
+            notes=f"Retry failed: {exc}",
+            reviewed_at=now,
+        )
+        await db.commit()
+        return {
+            "id": str(upload_id),
+            "status": "processing_failed",
+            "error": str(exc),
+        }
+
+    await _set_upload_status(
+        db, upload_id,
+        status="indexed",
+        reviewer_id=user.id,
+        notes=None,
+        reviewed_at=now,
+    )
+    await db.commit()
+    return {"id": str(upload_id), "status": "indexed", "reviewed_at": now.isoformat()}

--- a/src/d4bl/infra/vector_store.py
+++ b/src/d4bl/infra/vector_store.py
@@ -236,7 +236,17 @@ class VectorStore:
         total = len(chunks)
         inserted: list[UUID] = []
 
-        query = text("""
+        # Idempotent: drop any existing chunks for this upload before
+        # inserting the new set. Protects against duplicates after a
+        # partial failure (e.g., chunks committed, status update failed)
+        # and makes retry safe without requiring caller cleanup.
+        delete_existing = text("""
+            DELETE FROM scraped_content_vectors
+            WHERE source = 'staff_upload'
+              AND metadata ->> 'upload_id' = :upload_id
+        """)
+
+        insert_chunk = text("""
             INSERT INTO scraped_content_vectors
             (job_id, url, content, content_type, metadata, embedding, source)
             VALUES (NULL, :url, :content, :content_type, CAST(:metadata AS jsonb), CAST(:embedding AS vector), 'staff_upload')
@@ -244,6 +254,8 @@ class VectorStore:
         """)
 
         try:
+            await db.execute(delete_existing, {"upload_id": str(upload_id)})
+
             for i, chunk in enumerate(chunks):
                 embedding = await self.generate_embedding(chunk)
                 row_metadata = {
@@ -254,7 +266,7 @@ class VectorStore:
                     "source_type": "staff_upload",
                 }
                 result = await db.execute(
-                    query,
+                    insert_chunk,
                     {
                         "url": url,
                         "content": chunk,

--- a/src/d4bl/infra/vector_store.py
+++ b/src/d4bl/infra/vector_store.py
@@ -141,8 +141,8 @@ class VectorStore:
 
             query = text("""
                 INSERT INTO scraped_content_vectors
-                (job_id, url, content, content_type, metadata, embedding)
-                VALUES (:job_id, :url, :content, :content_type, CAST(:metadata AS jsonb), CAST(:embedding AS vector))
+                (job_id, url, content, content_type, metadata, embedding, source)
+                VALUES (:job_id, :url, :content, :content_type, CAST(:metadata AS jsonb), CAST(:embedding AS vector), 'research_job')
                 RETURNING id
             """)
 
@@ -202,6 +202,80 @@ class VectorStore:
 
         logger.info("Stored %s/%s items in vector DB", stored_count, len(items))
         return stored_count
+
+    async def store_staff_document(
+        self,
+        db: AsyncSession,
+        upload_id: UUID,
+        chunks: list[str],
+        metadata_base: dict[str, Any],
+    ) -> list[UUID]:
+        """Store staff-uploaded document chunks with embeddings.
+
+        Each chunk becomes one row in scraped_content_vectors with
+        source='staff_upload' and job_id=NULL. The per-chunk metadata
+        merges metadata_base with chunk_index/total_chunks/upload_id so
+        agents can cite the origin and reconstruct document order.
+
+        Args:
+            db: Database session
+            upload_id: Upload row this document came from
+            chunks: Output of chunker.chunk_text — one entry per chunk
+            metadata_base: Shared metadata (title, uploader_email,
+                source_url, original_filename, etc.)
+
+        Returns:
+            List of inserted row UUIDs in chunk order. Empty list if
+            no chunks were provided.
+        """
+        if not chunks:
+            return []
+
+        url = metadata_base.get("source_url")
+        content_type = metadata_base.get("content_type", "document")
+        total = len(chunks)
+        inserted: list[UUID] = []
+
+        query = text("""
+            INSERT INTO scraped_content_vectors
+            (job_id, url, content, content_type, metadata, embedding, source)
+            VALUES (NULL, :url, :content, :content_type, CAST(:metadata AS jsonb), CAST(:embedding AS vector), 'staff_upload')
+            RETURNING id
+        """)
+
+        try:
+            for i, chunk in enumerate(chunks):
+                embedding = await self.generate_embedding(chunk)
+                row_metadata = {
+                    **metadata_base,
+                    "upload_id": str(upload_id),
+                    "chunk_index": i,
+                    "total_chunks": total,
+                    "source_type": "staff_upload",
+                }
+                result = await db.execute(
+                    query,
+                    {
+                        "url": url,
+                        "content": chunk,
+                        "content_type": content_type,
+                        "metadata": json.dumps(row_metadata),
+                        "embedding": self._format_embedding(embedding),
+                    },
+                )
+                inserted.append(result.scalar_one())
+
+            await db.commit()
+            logger.info(
+                "Stored staff document upload_id=%s as %d chunks",
+                upload_id, total,
+            )
+            return inserted
+
+        except Exception:
+            logger.exception("Failed to store staff document upload_id=%s", upload_id)
+            await db.rollback()
+            raise
 
     async def search_similar(
         self,

--- a/src/d4bl/services/document_processing/__init__.py
+++ b/src/d4bl/services/document_processing/__init__.py
@@ -1,0 +1,1 @@
+"""Staff-upload document processing: extract, chunk, embed."""

--- a/src/d4bl/services/document_processing/approve.py
+++ b/src/d4bl/services/document_processing/approve.py
@@ -1,0 +1,102 @@
+"""Approval-time processing for staff document uploads.
+
+When an admin approves a ``document`` upload, this module reads the
+extracted full text that was stashed in metadata at submit time, chunks
+it, embeds each chunk via Ollama, and writes one row per chunk into the
+vector store.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from d4bl.infra.vector_store import get_vector_store
+
+from .chunker import chunk_text
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessingError(Exception):
+    """Raised when a document upload cannot be processed into the vector store."""
+
+
+async def process_document_upload(db: AsyncSession, upload_id: UUID) -> int:
+    """Chunk, embed, and index a document upload.
+
+    Reads the upload row + uploader email (via profiles join), pulls the
+    full extracted text out of ``metadata.full_text``, chunks it, and
+    calls ``VectorStore.store_staff_document`` to embed and write one
+    row per chunk.
+
+    Args:
+        db: Database session.
+        upload_id: The Upload.id to process.
+
+    Returns:
+        The number of chunks written to the vector store.
+
+    Raises:
+        ProcessingError: If the upload is missing, is not a document, or
+            has no extractable text. Vector-store and embedding errors
+            propagate as-is so the caller can distinguish input problems
+            from infrastructure problems.
+    """
+    result = await db.execute(
+        text(
+            """
+            SELECT u.id, u.upload_type, u.original_filename, u.metadata,
+                   p.email AS uploader_email
+            FROM uploads u
+            LEFT JOIN profiles p ON p.id = u.user_id
+            WHERE u.id = CAST(:uid AS uuid)
+            """
+        ),
+        {"uid": str(upload_id)},
+    )
+    row = result.mappings().first()
+    if not row:
+        raise ProcessingError(f"Upload {upload_id} not found")
+    if row["upload_type"] != "document":
+        raise ProcessingError(
+            f"Upload {upload_id} is not a document (type={row['upload_type']})"
+        )
+
+    metadata = row["metadata"] or {}
+    full_text = metadata.get("full_text")
+    if not full_text or not full_text.strip():
+        raise ProcessingError(
+            f"Upload {upload_id} has no extracted text to index"
+        )
+
+    chunks = chunk_text(full_text)
+    if not chunks:
+        raise ProcessingError(
+            f"Upload {upload_id} produced no chunks — text may be too short"
+        )
+
+    metadata_base = {
+        "title": metadata.get("title"),
+        "document_type": metadata.get("document_type"),
+        "topic_tags": metadata.get("topic_tags"),
+        "source_url": metadata.get("url"),
+        "original_filename": row["original_filename"],
+        "uploader_email": row["uploader_email"],
+    }
+
+    store = get_vector_store()
+    inserted = await store.store_staff_document(
+        db=db,
+        upload_id=upload_id,
+        chunks=chunks,
+        metadata_base=metadata_base,
+    )
+
+    logger.info(
+        "Processed document upload %s into %d chunks", upload_id, len(inserted)
+    )
+    return len(inserted)

--- a/src/d4bl/services/document_processing/chunker.py
+++ b/src/d4bl/services/document_processing/chunker.py
@@ -30,6 +30,15 @@ def chunk_text(
         A list of chunks. Empty or whitespace-only input returns [].
         Input shorter than MIN_CHUNK_SIZE is returned as a single chunk.
     """
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+    if overlap < 0:
+        raise ValueError("overlap must be non-negative")
+    # Reject degenerate overlap. overlap >= chunk_size forces stride = 1 in
+    # hard-split mode, producing O(n) chunks — almost certainly misconfig.
+    if overlap >= chunk_size:
+        raise ValueError("overlap must be strictly less than chunk_size")
+
     if not text or not text.strip():
         return []
 
@@ -46,8 +55,11 @@ def chunk_text(
         if len(para) > chunk_size:
             if buffer:
                 chunks.append(buffer)
-                buffer = ""
-            chunks.extend(_hard_split(para, chunk_size, overlap))
+            hard_chunks = _hard_split(para, chunk_size, overlap)
+            chunks.extend(hard_chunks)
+            # Seed next buffer with the tail of the final hard-split chunk
+            # so the next paragraph doesn't lose context across the seam.
+            buffer = hard_chunks[-1][-overlap:] if overlap and hard_chunks else ""
             continue
 
         if buffer and len(buffer) + 2 + len(para) > chunk_size:

--- a/src/d4bl/services/document_processing/chunker.py
+++ b/src/d4bl/services/document_processing/chunker.py
@@ -1,0 +1,70 @@
+"""Text chunking for embedding.
+
+Documents are split into overlapping chunks so that semantically related
+passages stay contiguous and retrieval returns enough context around a hit.
+"""
+
+from __future__ import annotations
+
+DEFAULT_CHUNK_SIZE = 500
+DEFAULT_OVERLAP = 100
+MIN_CHUNK_SIZE = 50
+
+
+def chunk_text(
+    text: str,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    overlap: int = DEFAULT_OVERLAP,
+) -> list[str]:
+    """Split text into overlapping chunks suitable for embedding.
+
+    Args:
+        text: The full document text (post-extraction).
+        chunk_size: Target characters per chunk. mxbai-embed-large handles
+            up to ~6000 chars, but smaller chunks give more precise retrieval.
+        overlap: Characters of tail from the previous chunk prepended to the
+            next, so a sentence split across chunk boundaries still appears
+            in full in at least one chunk.
+
+    Returns:
+        A list of chunks. Empty or whitespace-only input returns [].
+        Input shorter than MIN_CHUNK_SIZE is returned as a single chunk.
+    """
+    if not text or not text.strip():
+        return []
+
+    stripped = text.strip()
+    if len(stripped) <= MIN_CHUNK_SIZE:
+        return [stripped]
+
+    paragraphs = [p.strip() for p in stripped.split("\n\n") if p.strip()]
+
+    chunks: list[str] = []
+    buffer = ""
+
+    for para in paragraphs:
+        if len(para) > chunk_size:
+            if buffer:
+                chunks.append(buffer)
+                buffer = ""
+            chunks.extend(_hard_split(para, chunk_size, overlap))
+            continue
+
+        if buffer and len(buffer) + 2 + len(para) > chunk_size:
+            chunks.append(buffer)
+            buffer = buffer[-overlap:] + "\n\n" + para if overlap else para
+        elif buffer:
+            buffer = buffer + "\n\n" + para
+        else:
+            buffer = para
+
+    if buffer:
+        chunks.append(buffer)
+
+    return chunks
+
+
+def _hard_split(text: str, chunk_size: int, overlap: int) -> list[str]:
+    """Character-window split for paragraphs larger than chunk_size."""
+    stride = max(chunk_size - overlap, 1)
+    return [text[i : i + chunk_size] for i in range(0, len(text), stride)]

--- a/src/d4bl/services/document_processing/chunker.py
+++ b/src/d4bl/services/document_processing/chunker.py
@@ -71,7 +71,15 @@ def chunk_text(
 
         if buffer and len(buffer) + 2 + len(para) > chunk_size:
             chunks.append(buffer)
-            buffer = buffer[-overlap:] + "\n\n" + para if overlap else para
+            if overlap:
+                # Cap carried tail to the space left for para so the new
+                # chunk never exceeds chunk_size. If para alone fills the
+                # budget, drop the tail entirely.
+                max_tail = max(chunk_size - len(para) - 2, 0)
+                tail_len = min(overlap, max_tail)
+                buffer = f"{buffer[-tail_len:]}\n\n{para}" if tail_len else para
+            else:
+                buffer = para
         elif buffer:
             buffer = buffer + "\n\n" + para
         else:
@@ -84,6 +92,15 @@ def chunk_text(
 
 
 def _hard_split(text: str, chunk_size: int, overlap: int) -> list[str]:
-    """Character-window split for paragraphs larger than chunk_size."""
+    """Character-window split for paragraphs larger than chunk_size.
+
+    Stops once a window reaches EOF so a trailing slice fully covered by
+    the previous window is not emitted as a duplicate.
+    """
     stride = max(chunk_size - overlap, 1)
-    return [text[i : i + chunk_size] for i in range(0, len(text), stride)]
+    result: list[str] = []
+    for start in range(0, len(text), stride):
+        result.append(text[start : start + chunk_size])
+        if start + chunk_size >= len(text):
+            break
+    return result

--- a/src/d4bl/services/document_processing/chunker.py
+++ b/src/d4bl/services/document_processing/chunker.py
@@ -50,16 +50,23 @@ def chunk_text(
 
     chunks: list[str] = []
     buffer = ""
+    # carryover holds the tail of the last hard-split chunk so the next
+    # paragraph can start with that context — but it's never emitted as a
+    # standalone chunk (that would create overlap-only duplicates).
+    carryover = ""
 
     for para in paragraphs:
+        if carryover:
+            para = carryover + "\n\n" + para
+            carryover = ""
+
         if len(para) > chunk_size:
             if buffer:
                 chunks.append(buffer)
+                buffer = ""
             hard_chunks = _hard_split(para, chunk_size, overlap)
             chunks.extend(hard_chunks)
-            # Seed next buffer with the tail of the final hard-split chunk
-            # so the next paragraph doesn't lose context across the seam.
-            buffer = hard_chunks[-1][-overlap:] if overlap and hard_chunks else ""
+            carryover = hard_chunks[-1][-overlap:] if overlap and hard_chunks else ""
             continue
 
         if buffer and len(buffer) + 2 + len(para) > chunk_size:

--- a/src/d4bl/services/document_processing/extractors.py
+++ b/src/d4bl/services/document_processing/extractors.py
@@ -1,0 +1,97 @@
+"""Text extractors for staff-uploaded documents.
+
+Each extractor returns the raw text. Empty or near-empty results raise
+``ExtractionError`` so the caller can surface a clear message to the admin.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import httpx
+import trafilatura
+from docx import Document as DocxDocument
+from pypdf import PdfReader
+
+logger = logging.getLogger(__name__)
+
+MIN_TEXT_LENGTH = 50
+URL_FETCH_TIMEOUT = 30.0
+
+
+class ExtractionError(Exception):
+    """Raised when a document cannot be extracted to usable text."""
+
+
+def extract_pdf(content: bytes) -> str:
+    """Extract text from PDF bytes using pypdf.
+
+    Raises ExtractionError if the PDF yields fewer than MIN_TEXT_LENGTH
+    characters (likely scanned/image-based and needs OCR).
+    """
+    try:
+        reader = PdfReader(io.BytesIO(content))
+    except Exception as exc:
+        raise ExtractionError(f"Could not open PDF: {exc}") from exc
+
+    pages_text: list[str] = []
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        if text.strip():
+            pages_text.append(text)
+
+    full_text = "\n\n".join(pages_text).strip()
+    if len(full_text) < MIN_TEXT_LENGTH:
+        raise ExtractionError(
+            "PDF yielded no usable text. It may be scanned/image-based; OCR is not supported."
+        )
+    return full_text
+
+
+def extract_docx(content: bytes) -> str:
+    """Extract text from DOCX bytes using python-docx."""
+    try:
+        doc = DocxDocument(io.BytesIO(content))
+    except Exception as exc:
+        raise ExtractionError(f"Could not open DOCX: {exc}") from exc
+
+    paragraphs = [p.text for p in doc.paragraphs if p.text and p.text.strip()]
+    full_text = "\n\n".join(paragraphs).strip()
+    if len(full_text) < MIN_TEXT_LENGTH:
+        raise ExtractionError("DOCX contained no extractable text.")
+    return full_text
+
+
+def extract_url(url: str, *, timeout: float = URL_FETCH_TIMEOUT) -> str:
+    """Fetch a URL and extract the main content as plain text.
+
+    Uses httpx to fetch and trafilatura to strip boilerplate. PDF URLs are
+    routed through extract_pdf. Falls back to ExtractionError on failure;
+    JS-rendered pages are not retried via Crawl4AI in this path — staff
+    contributors can upload the PDF directly if trafilatura cannot extract.
+    """
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            response = client.get(url)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise ExtractionError(f"Could not fetch URL: {exc}") from exc
+
+    content_type = response.headers.get("content-type", "").lower()
+    if "application/pdf" in content_type or url.lower().endswith(".pdf"):
+        return extract_pdf(response.content)
+
+    text = trafilatura.extract(
+        response.text,
+        url=url,
+        include_comments=False,
+        include_tables=True,
+        favor_recall=True,
+    )
+    if not text or len(text.strip()) < MIN_TEXT_LENGTH:
+        raise ExtractionError(
+            "Could not extract readable content from URL. "
+            "If the page is JavaScript-heavy, upload the document as a file instead."
+        )
+    return text.strip()

--- a/supabase/migrations/20260418000000_staff_documents_vectors.sql
+++ b/supabase/migrations/20260418000000_staff_documents_vectors.sql
@@ -11,5 +11,12 @@ ALTER TABLE scraped_content_vectors
 CREATE INDEX IF NOT EXISTS scraped_content_vectors_source_idx
     ON scraped_content_vectors(source);
 
+-- Enforce the invariant that every research-job row still has a job_id.
+-- Staff-upload rows are allowed to have job_id = NULL; other future source
+-- types are unconstrained by this check.
+ALTER TABLE scraped_content_vectors
+    ADD CONSTRAINT scraped_content_vectors_source_job_id_check
+    CHECK (source <> 'research_job' OR job_id IS NOT NULL);
+
 -- Staff-upload rows will have source = 'staff_upload' and job_id = NULL.
 -- Research-job rows keep source = 'research_job' and job_id = <uuid>.

--- a/supabase/migrations/20260418000000_staff_documents_vectors.sql
+++ b/supabase/migrations/20260418000000_staff_documents_vectors.sql
@@ -1,0 +1,15 @@
+-- Relax scraped_content_vectors.job_id so staff-contributed documents
+-- (which do not belong to a research job) can live in the same table.
+-- Add a `source` column to distinguish research-job content from staff uploads.
+
+ALTER TABLE scraped_content_vectors
+    ALTER COLUMN job_id DROP NOT NULL;
+
+ALTER TABLE scraped_content_vectors
+    ADD COLUMN IF NOT EXISTS source VARCHAR(30) NOT NULL DEFAULT 'research_job';
+
+CREATE INDEX IF NOT EXISTS scraped_content_vectors_source_idx
+    ON scraped_content_vectors(source);
+
+-- Staff-upload rows will have source = 'staff_upload' and job_id = NULL.
+-- Research-job rows keep source = 'research_job' and job_id = <uuid>.

--- a/supabase/migrations/20260418000001_add_indexed_processing_failed_upload_statuses.sql
+++ b/supabase/migrations/20260418000001_add_indexed_processing_failed_upload_statuses.sql
@@ -1,0 +1,7 @@
+-- Add new upload_status enum values used by the document indexing pipeline.
+-- ``indexed`` marks a document upload whose chunks have been written to the
+-- vector store. ``processing_failed`` marks an approval where chunking or
+-- embedding raised; the admin can retry via the admin API.
+
+ALTER TYPE upload_status ADD VALUE IF NOT EXISTS 'indexed';
+ALTER TYPE upload_status ADD VALUE IF NOT EXISTS 'processing_failed';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for D4BL tests."""
 
+import io
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -7,6 +8,25 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from d4bl.app.auth import CurrentUser, get_current_user
+
+
+@pytest.fixture
+def make_pdf_bytes():
+    """Factory fixture: given a list of text lines, produce a PDF byte string
+    that pypdf can parse. Used by document-processing and upload-API tests."""
+    from reportlab.pdfgen import canvas
+
+    def _make(lines: list[str]) -> bytes:
+        buf = io.BytesIO()
+        c = canvas.Canvas(buf)
+        y = 800
+        for line in lines:
+            c.drawString(100, y, line)
+            y -= 20
+        c.save()
+        return buf.getvalue()
+
+    return _make
 
 _PATCH_SETTINGS_SECRET = "test-jwt-secret"
 

--- a/tests/test_document_processing.py
+++ b/tests/test_document_processing.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 import pytest
 from docx import Document as DocxDocument
 from pypdf import PdfWriter
-from reportlab.pdfgen import canvas
 
 from d4bl.services.document_processing.approve import (
     ProcessingError,
@@ -28,18 +27,6 @@ from d4bl.services.document_processing.extractors import (
 )
 
 
-def _make_pdf_bytes(lines: list[str]) -> bytes:
-    """Build a real PDF in memory using reportlab so pypdf can parse it."""
-    buf = io.BytesIO()
-    c = canvas.Canvas(buf)
-    y = 800
-    for line in lines:
-        c.drawString(100, y, line)
-        y -= 20
-    c.save()
-    return buf.getvalue()
-
-
 def _make_docx_bytes(paragraphs: list[str]) -> bytes:
     buf = io.BytesIO()
     doc = DocxDocument()
@@ -50,8 +37,8 @@ def _make_docx_bytes(paragraphs: list[str]) -> bytes:
 
 
 class TestExtractPdf:
-    def test_extracts_text_from_valid_pdf(self):
-        pdf_bytes = _make_pdf_bytes([
+    def test_extracts_text_from_valid_pdf(self, make_pdf_bytes):
+        pdf_bytes = make_pdf_bytes([
             "The racial wealth gap has widened over the past decade.",
             "Black homeownership rates trail white homeownership by 30 points.",
         ])
@@ -140,6 +127,30 @@ class TestChunkText:
     def test_defaults_are_reasonable(self):
         assert DEFAULT_CHUNK_SIZE > DEFAULT_OVERLAP > 0
 
+    def test_rejects_non_positive_chunk_size(self):
+        with pytest.raises(ValueError, match="chunk_size must be positive"):
+            chunk_text("some text", chunk_size=0, overlap=0)
+
+    def test_rejects_negative_overlap(self):
+        with pytest.raises(ValueError, match="overlap must be non-negative"):
+            chunk_text("some text", chunk_size=100, overlap=-1)
+
+    def test_rejects_overlap_geq_chunk_size(self):
+        """overlap >= chunk_size raises instead of exploding to O(n) chunks."""
+        with pytest.raises(ValueError, match="strictly less than chunk_size"):
+            chunk_text("x" * 2000, chunk_size=100, overlap=500)
+
+    def test_overlap_carries_across_hard_split_seam(self):
+        """After hard-splitting a big paragraph, the next paragraph's chunk
+        carries the tail of the hard-split chunk so context isn't lost."""
+        big_para = "A" * 1000
+        follow = "B paragraph content that continues the discussion"
+        text = big_para + "\n\n" + follow
+        chunks = chunk_text(text, chunk_size=400, overlap=80)
+        # The follow-up chunk should contain some trailing As from the
+        # hard-split tail in addition to the new paragraph text.
+        assert any("A" * 20 in c and "B paragraph" in c for c in chunks)
+
 
 def _mock_upload_row(
     *,
@@ -210,6 +221,14 @@ class TestProcessDocumentUpload:
     async def test_missing_full_text_raises(self):
         db = AsyncMock()
         db.execute = AsyncMock(return_value=_mock_upload_row(full_text=None))
+
+        with pytest.raises(ProcessingError, match="no extracted text"):
+            await process_document_upload(db, uuid4())
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_full_text_raises(self):
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_mock_upload_row(full_text="   \n\n  "))
 
         with pytest.raises(ProcessingError, match="no extracted text"):
             await process_document_upload(db, uuid4())

--- a/tests/test_document_processing.py
+++ b/tests/test_document_processing.py
@@ -1,0 +1,135 @@
+"""Tests for document_processing extractors and chunker."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from docx import Document as DocxDocument
+from pypdf import PdfWriter
+from reportlab.pdfgen import canvas
+
+from d4bl.services.document_processing.chunker import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_OVERLAP,
+    MIN_CHUNK_SIZE,
+    chunk_text,
+)
+from d4bl.services.document_processing.extractors import (
+    ExtractionError,
+    extract_docx,
+    extract_pdf,
+)
+
+
+def _make_pdf_bytes(lines: list[str]) -> bytes:
+    """Build a real PDF in memory using reportlab so pypdf can parse it."""
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf)
+    y = 800
+    for line in lines:
+        c.drawString(100, y, line)
+        y -= 20
+    c.save()
+    return buf.getvalue()
+
+
+def _make_docx_bytes(paragraphs: list[str]) -> bytes:
+    buf = io.BytesIO()
+    doc = DocxDocument()
+    for p in paragraphs:
+        doc.add_paragraph(p)
+    doc.save(buf)
+    return buf.getvalue()
+
+
+class TestExtractPdf:
+    def test_extracts_text_from_valid_pdf(self):
+        pdf_bytes = _make_pdf_bytes([
+            "The racial wealth gap has widened over the past decade.",
+            "Black homeownership rates trail white homeownership by 30 points.",
+        ])
+        text = extract_pdf(pdf_bytes)
+        assert "racial wealth gap" in text
+        assert "homeownership" in text
+
+    def test_rejects_malformed_pdf(self):
+        with pytest.raises(ExtractionError, match="Could not open PDF"):
+            extract_pdf(b"not a pdf")
+
+    def test_rejects_pdf_with_no_text(self):
+        writer = PdfWriter()
+        writer.add_blank_page(width=72, height=72)
+        buf = io.BytesIO()
+        writer.write(buf)
+        with pytest.raises(ExtractionError, match="no usable text"):
+            extract_pdf(buf.getvalue())
+
+
+class TestExtractDocx:
+    def test_extracts_text_from_valid_docx(self):
+        docx_bytes = _make_docx_bytes([
+            "Environmental racism concentrates hazardous waste near Black communities.",
+            "Policy levers include zoning reform and cumulative impact analysis.",
+        ])
+        text = extract_docx(docx_bytes)
+        assert "Environmental racism" in text
+        assert "zoning reform" in text
+
+    def test_rejects_malformed_docx(self):
+        with pytest.raises(ExtractionError, match="Could not open DOCX"):
+            extract_docx(b"not a docx")
+
+    def test_rejects_empty_docx(self):
+        docx_bytes = _make_docx_bytes([])
+        with pytest.raises(ExtractionError, match="no extractable text"):
+            extract_docx(docx_bytes)
+
+
+class TestChunkText:
+    def test_empty_input_returns_empty_list(self):
+        assert chunk_text("") == []
+        assert chunk_text("   \n\n  ") == []
+
+    def test_short_input_returns_single_chunk(self):
+        text = "one short paragraph"
+        assert chunk_text(text) == [text]
+
+    def test_respects_chunk_size_for_long_paragraphs(self):
+        para = "a" * 2000
+        chunks = chunk_text(para, chunk_size=500, overlap=100)
+        assert all(len(c) <= 500 for c in chunks)
+        assert len(chunks) >= 4
+
+    def test_packs_short_paragraphs_together(self):
+        paras = ["paragraph one.", "paragraph two.", "paragraph three."]
+        chunks = chunk_text("\n\n".join(paras), chunk_size=500, overlap=100)
+        assert len(chunks) == 1
+        assert "paragraph one" in chunks[0]
+        assert "paragraph three" in chunks[0]
+
+    def test_overlap_preserves_context_across_chunks(self):
+        paras = [
+            "A" * 200,
+            "B" * 200,
+            "C" * 200,
+        ]
+        chunks = chunk_text("\n\n".join(paras), chunk_size=250, overlap=50)
+        assert len(chunks) >= 2
+        tail_of_first = chunks[0][-50:]
+        assert tail_of_first in chunks[1]
+
+    def test_preserves_chunk_ordering(self):
+        parts = ["alpha", "beta", "gamma", "delta", "epsilon"]
+        text = "\n\n".join(p * 100 for p in parts)
+        chunks = chunk_text(text, chunk_size=300, overlap=50)
+        joined = " ".join(chunks)
+        for i in range(len(parts) - 1):
+            assert joined.find(parts[i]) < joined.find(parts[i + 1])
+
+    def test_exactly_min_chunk_size_is_single_chunk(self):
+        text = "x" * MIN_CHUNK_SIZE
+        assert chunk_text(text) == [text]
+
+    def test_defaults_are_reasonable(self):
+        assert DEFAULT_CHUNK_SIZE > DEFAULT_OVERLAP > 0

--- a/tests/test_document_processing.py
+++ b/tests/test_document_processing.py
@@ -151,6 +151,31 @@ class TestChunkText:
         # hard-split tail in addition to the new paragraph text.
         assert any("A" * 20 in c and "B paragraph" in c for c in chunks)
 
+    def test_no_overlap_only_chunk_at_eof_after_hard_split(self):
+        """A document ending on a hard-split paragraph must not emit a
+        trailing chunk that is just the overlap tail — that would be an
+        embedded duplicate that skews retrieval."""
+        big_para = "A" * 1000
+        chunks = chunk_text(big_para, chunk_size=400, overlap=80)
+        # No chunk should be purely the overlap tail from a previous chunk
+        # (that would mean the carryover leaked into the output).
+        for i in range(len(chunks) - 1):
+            tail = chunks[i][-80:]
+            assert chunks[i + 1] != tail, (
+                f"Chunk {i + 1} is just the overlap tail of chunk {i}"
+            )
+
+    def test_no_overlap_only_chunk_between_back_to_back_hard_splits(self):
+        """Two oversized paragraphs in a row must not produce an overlap-only
+        chunk between them."""
+        big_a = "A" * 1000
+        big_b = "B" * 1000
+        chunks = chunk_text(big_a + "\n\n" + big_b, chunk_size=400, overlap=80)
+        # No chunk should consist purely of one character repeated for
+        # exactly overlap chars (which is what the old bug would produce).
+        overlap_only = [c for c in chunks if c == "A" * 80 or c == "B" * 80]
+        assert overlap_only == []
+
 
 def _mock_upload_row(
     *,

--- a/tests/test_document_processing.py
+++ b/tests/test_document_processing.py
@@ -1,14 +1,20 @@
-"""Tests for document_processing extractors and chunker."""
+"""Tests for document_processing extractors, chunker, and approve flow."""
 
 from __future__ import annotations
 
 import io
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from docx import Document as DocxDocument
 from pypdf import PdfWriter
 from reportlab.pdfgen import canvas
 
+from d4bl.services.document_processing.approve import (
+    ProcessingError,
+    process_document_upload,
+)
 from d4bl.services.document_processing.chunker import (
     DEFAULT_CHUNK_SIZE,
     DEFAULT_OVERLAP,
@@ -133,3 +139,77 @@ class TestChunkText:
 
     def test_defaults_are_reasonable(self):
         assert DEFAULT_CHUNK_SIZE > DEFAULT_OVERLAP > 0
+
+
+def _mock_upload_row(
+    *,
+    upload_type: str = "document",
+    full_text: str | None = "Some extracted text about racial equity.\n\nMore content.",
+    title: str = "Test Doc",
+    uploader_email: str = "alice@d4bl.org",
+    filename: str = "doc.pdf",
+):
+    mapping = {
+        "id": uuid4(),
+        "upload_type": upload_type,
+        "original_filename": filename,
+        "metadata": {
+            "title": title,
+            "document_type": "report",
+            "topic_tags": ["equity"],
+            "url": None,
+            "full_text": full_text,
+        },
+        "uploader_email": uploader_email,
+    }
+    result = MagicMock()
+    result.mappings.return_value.first.return_value = mapping
+    return result
+
+
+class TestProcessDocumentUpload:
+
+    @pytest.mark.asyncio
+    @patch("d4bl.services.document_processing.approve.get_vector_store")
+    async def test_happy_path_chunks_and_indexes(self, mock_get_store):
+        fake_store = MagicMock()
+        fake_store.store_staff_document = AsyncMock(return_value=[uuid4(), uuid4()])
+        mock_get_store.return_value = fake_store
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_mock_upload_row())
+
+        count = await process_document_upload(db, uuid4())
+
+        assert count == 2
+        fake_store.store_staff_document.assert_awaited_once()
+        call_kwargs = fake_store.store_staff_document.await_args.kwargs
+        assert call_kwargs["metadata_base"]["title"] == "Test Doc"
+        assert call_kwargs["metadata_base"]["uploader_email"] == "alice@d4bl.org"
+        assert call_kwargs["chunks"]  # non-empty
+
+    @pytest.mark.asyncio
+    async def test_missing_upload_raises(self):
+        db = AsyncMock()
+        result = MagicMock()
+        result.mappings.return_value.first.return_value = None
+        db.execute = AsyncMock(return_value=result)
+
+        with pytest.raises(ProcessingError, match="not found"):
+            await process_document_upload(db, uuid4())
+
+    @pytest.mark.asyncio
+    async def test_non_document_upload_raises(self):
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_mock_upload_row(upload_type="datasource"))
+
+        with pytest.raises(ProcessingError, match="not a document"):
+            await process_document_upload(db, uuid4())
+
+    @pytest.mark.asyncio
+    async def test_missing_full_text_raises(self):
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_mock_upload_row(full_text=None))
+
+        with pytest.raises(ProcessingError, match="no extracted text"):
+            await process_document_upload(db, uuid4())

--- a/tests/test_document_processing.py
+++ b/tests/test_document_processing.py
@@ -102,6 +102,9 @@ class TestChunkText:
         assert "paragraph three" in chunks[0]
 
     def test_overlap_preserves_context_across_chunks(self):
+        """Rolled-over chunks carry as much tail context as fits within
+        chunk_size. The full overlap is ideal; a shorter tail is acceptable
+        when the next paragraph would push the chunk over the limit."""
         paras = [
             "A" * 200,
             "B" * 200,
@@ -109,8 +112,9 @@ class TestChunkText:
         ]
         chunks = chunk_text("\n\n".join(paras), chunk_size=250, overlap=50)
         assert len(chunks) >= 2
-        tail_of_first = chunks[0][-50:]
-        assert tail_of_first in chunks[1]
+        # Some As from the end of chunk 0 must appear at the start of chunk 1.
+        assert chunks[1].startswith("A")
+        assert chunks[0][-1] == "A"
 
     def test_preserves_chunk_ordering(self):
         parts = ["alpha", "beta", "gamma", "delta", "epsilon"]
@@ -175,6 +179,32 @@ class TestChunkText:
         # exactly overlap chars (which is what the old bug would produce).
         overlap_only = [c for c in chunks if c == "A" * 80 or c == "B" * 80]
         assert overlap_only == []
+
+    def test_rollover_chunk_never_exceeds_chunk_size(self):
+        """Flushing a near-full buffer before a near-full paragraph must not
+        emit a chunk larger than chunk_size even with overlap carried."""
+        # buffer fills with 3 paragraphs of ~100 chars (under 400), then a
+        # 300-char paragraph triggers flush; carried overlap + 300 should be
+        # capped at chunk_size.
+        text = "\n\n".join([
+            "A" * 100,
+            "A" * 100,
+            "A" * 100,
+            "B" * 300,
+        ])
+        chunks = chunk_text(text, chunk_size=400, overlap=100)
+        assert all(len(c) <= 400 for c in chunks), [len(c) for c in chunks]
+
+    def test_hard_split_does_not_emit_redundant_trailing_window(self):
+        """_hard_split must stop once a window reaches EOF — otherwise a
+        40-char tail fully covered by the previous window gets duplicated."""
+        text = "A" * 1000
+        chunks = chunk_text(text, chunk_size=400, overlap=80)
+        # With stride=320 and chunk_size=400, we expect 3 windows
+        # [0:400], [320:720], [640:1000]. A 4th window [960:1000] would be
+        # a 40-char duplicate — fully contained in the previous window.
+        assert len(chunks) == 3
+        assert chunks[-1] == text[640:1000]
 
 
 def _mock_upload_row(

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -1,12 +1,13 @@
 """Tests for staff upload API schemas and endpoints."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from pydantic import ValidationError
 
 from d4bl.app.api import app
+from d4bl.services.document_processing.extractors import ExtractionError
 
 
 class TestUploadSchemas:
@@ -215,6 +216,110 @@ class TestUploadEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["upload_type"] == "feature_request"
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.extract_url")
+    async def test_upload_document_url_populates_preview(
+        self, mock_extract, user_client, override_db
+    ):
+        """URL-based document upload fetches preview text on submit."""
+        mock_extract.return_value = "Full extracted article text about racial equity."
+        mock_result = MagicMock()
+        mock_result.scalar_one.return_value = None
+        override_db.execute = AsyncMock(return_value=mock_result)
+
+        resp = await user_client.post(
+            "/api/admin/uploads/document",
+            data={
+                "title": "ProPublica racial equity investigation",
+                "document_type": "article",
+                "url": "https://propublica.org/article",
+            },
+        )
+
+        assert resp.status_code == 200
+        mock_extract.assert_called_once_with("https://propublica.org/article")
+        # The ORM object wrote the preview into metadata_; we can't read it back
+        # from the response, but we can confirm the call path by inspecting the
+        # upload captured via override_db.add.
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.extract_url")
+    async def test_upload_document_url_extraction_failure_returns_422(
+        self, mock_extract, user_client, override_db
+    ):
+        """If URL extraction fails, caller sees a 422 with the error message."""
+        mock_extract.side_effect = ExtractionError("Could not fetch URL: network timeout")
+        override_db.execute = AsyncMock()
+
+        resp = await user_client.post(
+            "/api/admin/uploads/document",
+            data={
+                "title": "Broken link",
+                "document_type": "article",
+                "url": "https://unreachable.example/404",
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "Could not extract content" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.extract_url")
+    async def test_upload_document_preview_is_truncated(
+        self, mock_extract, user_client, override_db
+    ):
+        """Preview text is capped at MAX_PREVIEW_CHARS."""
+        from d4bl.app.upload_routes import MAX_PREVIEW_CHARS
+
+        mock_extract.return_value = "x" * (MAX_PREVIEW_CHARS * 3)
+        override_db.execute = AsyncMock()
+
+        captured: dict = {}
+
+        def capture_add(obj):
+            captured["upload"] = obj
+
+        override_db.add = capture_add
+
+        resp = await user_client.post(
+            "/api/admin/uploads/document",
+            data={
+                "title": "Very long article",
+                "document_type": "article",
+                "url": "https://example.com/long",
+            },
+        )
+
+        assert resp.status_code == 200
+        upload = captured["upload"]
+        assert len(upload.metadata_["preview_text"]) == MAX_PREVIEW_CHARS
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.extract_url")
+    async def test_upload_document_file_skips_url_fetch(
+        self, mock_extract, user_client, override_db
+    ):
+        """File uploads don't trigger a URL fetch, and preview stays None."""
+        override_db.execute = AsyncMock()
+        captured: dict = {}
+
+        def capture_add(obj):
+            captured["upload"] = obj
+
+        override_db.add = capture_add
+
+        fake_pdf = b"%PDF-1.4\n%%EOF\n" + b"x" * 100
+        resp = await user_client.post(
+            "/api/admin/uploads/document",
+            data={"title": "Report", "document_type": "report"},
+            files={"file": ("test.pdf", fake_pdf, "application/pdf")},
+        )
+
+        assert resp.status_code == 200
+        mock_extract.assert_not_called()
+        upload = captured["upload"]
+        assert upload.metadata_["preview_text"] is None
 
     @pytest.mark.asyncio
     async def test_list_uploads_requires_auth(self, unauth_client):

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -1,13 +1,26 @@
 """Tests for staff upload API schemas and endpoints."""
 
+import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from pydantic import ValidationError
+from reportlab.pdfgen import canvas
 
 from d4bl.app.api import app
 from d4bl.services.document_processing.extractors import ExtractionError
+
+
+def _make_pdf_bytes(lines: list[str]) -> bytes:
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf)
+    y = 800
+    for line in lines:
+        c.drawString(100, y, line)
+        y -= 20
+    c.save()
+    return buf.getvalue()
 
 
 class TestUploadSchemas:
@@ -297,10 +310,10 @@ class TestUploadEndpoints:
 
     @pytest.mark.asyncio
     @patch("d4bl.app.upload_routes.extract_url")
-    async def test_upload_document_file_skips_url_fetch(
+    async def test_upload_document_file_extracts_text_at_submit(
         self, mock_extract, user_client, override_db
     ):
-        """File uploads don't trigger a URL fetch, and preview stays None."""
+        """PDF file uploads extract text at submit time, not URL fetch."""
         override_db.execute = AsyncMock()
         captured: dict = {}
 
@@ -309,17 +322,37 @@ class TestUploadEndpoints:
 
         override_db.add = capture_add
 
-        fake_pdf = b"%PDF-1.4\n%%EOF\n" + b"x" * 100
+        pdf_bytes = _make_pdf_bytes([
+            "The racial wealth gap has widened over the past decade.",
+            "Homeownership rates trail by 30 percentage points.",
+        ])
         resp = await user_client.post(
             "/api/admin/uploads/document",
             data={"title": "Report", "document_type": "report"},
-            files={"file": ("test.pdf", fake_pdf, "application/pdf")},
+            files={"file": ("test.pdf", pdf_bytes, "application/pdf")},
         )
 
         assert resp.status_code == 200
         mock_extract.assert_not_called()
         upload = captured["upload"]
-        assert upload.metadata_["preview_text"] is None
+        assert "racial wealth gap" in upload.metadata_["full_text"]
+        assert "racial wealth gap" in upload.metadata_["preview_text"]
+
+    @pytest.mark.asyncio
+    async def test_upload_document_bad_pdf_returns_422(
+        self, user_client, override_db
+    ):
+        """Malformed PDF bytes fail extraction and yield 422."""
+        override_db.execute = AsyncMock()
+
+        resp = await user_client.post(
+            "/api/admin/uploads/document",
+            data={"title": "Report", "document_type": "report"},
+            files={"file": ("test.pdf", b"not a pdf", "application/pdf")},
+        )
+
+        assert resp.status_code == 422
+        assert "Could not extract content from file" in resp.json()["detail"]
 
     @pytest.mark.asyncio
     async def test_list_uploads_requires_auth(self, unauth_client):
@@ -331,5 +364,140 @@ class TestUploadEndpoints:
         resp = await user_client.patch(
             "/api/admin/uploads/00000000-0000-0000-0000-000000000001/review",
             json={"action": "approve"},
+        )
+        assert resp.status_code == 403
+
+
+def _mock_review_lookup(mock_session, upload_type: str, status: str = "pending_review"):
+    """Wire up mock execute to return a single upload row then accept updates."""
+    lookup = MagicMock()
+    lookup.mappings.return_value.first.return_value = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "status": status,
+        "upload_type": upload_type,
+    }
+    update_result = MagicMock()
+    mock_session.execute = AsyncMock(side_effect=[lookup, update_result, update_result])
+    mock_session.commit = AsyncMock()
+
+
+class TestReviewFlow:
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.process_document_upload")
+    async def test_approve_document_runs_processor_and_marks_indexed(
+        self, mock_process, admin_client, override_db
+    ):
+        mock_process.return_value = 5  # 5 chunks written
+        _mock_review_lookup(override_db, upload_type="document")
+
+        resp = await admin_client.patch(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/review",
+            json={"action": "approve"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "indexed"
+        mock_process.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.process_document_upload")
+    async def test_approve_document_processing_failure_marks_processing_failed(
+        self, mock_process, admin_client, override_db
+    ):
+        mock_process.side_effect = RuntimeError("ollama unavailable")
+        _mock_review_lookup(override_db, upload_type="document")
+
+        resp = await admin_client.patch(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/review",
+            json={"action": "approve"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "processing_failed"
+        assert "ollama unavailable" in body["error"]
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.process_document_upload")
+    async def test_approve_non_document_skips_processing(
+        self, mock_process, admin_client, override_db
+    ):
+        """Datasource/query approvals don't trigger document processing."""
+        _mock_review_lookup(override_db, upload_type="datasource")
+
+        resp = await admin_client.patch(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/review",
+            json={"action": "approve"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "approved"
+        mock_process.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.process_document_upload")
+    async def test_reject_document_skips_processing(
+        self, mock_process, admin_client, override_db
+    ):
+        _mock_review_lookup(override_db, upload_type="document")
+
+        resp = await admin_client.patch(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/review",
+            json={"action": "reject", "notes": "Not relevant"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "rejected"
+        mock_process.assert_not_called()
+
+
+class TestRetryProcessing:
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.process_document_upload")
+    async def test_retry_happy_path(self, mock_process, admin_client, override_db):
+        mock_process.return_value = 3
+        _mock_review_lookup(
+            override_db, upload_type="document", status="processing_failed"
+        )
+
+        resp = await admin_client.post(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/retry-processing",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "indexed"
+
+    @pytest.mark.asyncio
+    async def test_retry_rejects_non_failed_upload(self, admin_client, override_db):
+        _mock_review_lookup(
+            override_db, upload_type="document", status="indexed"
+        )
+
+        resp = await admin_client.post(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/retry-processing",
+        )
+
+        assert resp.status_code == 400
+        assert "not processing_failed" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_retry_rejects_non_document(self, admin_client, override_db):
+        _mock_review_lookup(
+            override_db, upload_type="datasource", status="processing_failed"
+        )
+
+        resp = await admin_client.post(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/retry-processing",
+        )
+
+        assert resp.status_code == 400
+        assert "Only document uploads" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_retry_requires_admin(self, user_client):
+        resp = await user_client.post(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/retry-processing",
         )
         assert resp.status_code == 403

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -1,26 +1,13 @@
 """Tests for staff upload API schemas and endpoints."""
 
-import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from pydantic import ValidationError
-from reportlab.pdfgen import canvas
 
 from d4bl.app.api import app
 from d4bl.services.document_processing.extractors import ExtractionError
-
-
-def _make_pdf_bytes(lines: list[str]) -> bytes:
-    buf = io.BytesIO()
-    c = canvas.Canvas(buf)
-    y = 800
-    for line in lines:
-        c.drawString(100, y, line)
-        y -= 20
-    c.save()
-    return buf.getvalue()
 
 
 class TestUploadSchemas:
@@ -311,7 +298,7 @@ class TestUploadEndpoints:
     @pytest.mark.asyncio
     @patch("d4bl.app.upload_routes.extract_url")
     async def test_upload_document_file_extracts_text_at_submit(
-        self, mock_extract, user_client, override_db
+        self, mock_extract, user_client, override_db, make_pdf_bytes
     ):
         """PDF file uploads extract text at submit time, not URL fetch."""
         override_db.execute = AsyncMock()
@@ -322,7 +309,7 @@ class TestUploadEndpoints:
 
         override_db.add = capture_add
 
-        pdf_bytes = _make_pdf_bytes([
+        pdf_bytes = make_pdf_bytes([
             "The racial wealth gap has widened over the past decade.",
             "Homeownership rates trail by 30 percentage points.",
         ])
@@ -368,13 +355,19 @@ class TestUploadEndpoints:
         assert resp.status_code == 403
 
 
-def _mock_review_lookup(mock_session, upload_type: str, status: str = "pending_review"):
+def _mock_review_lookup(
+    mock_session,
+    upload_type: str,
+    status: str = "pending_review",
+    reviewer_notes: str | None = None,
+):
     """Wire up mock execute to return a single upload row then accept updates."""
     lookup = MagicMock()
     lookup.mappings.return_value.first.return_value = {
         "id": "00000000-0000-0000-0000-000000000001",
         "status": status,
         "upload_type": upload_type,
+        "reviewer_notes": reviewer_notes,
     }
     update_result = MagicMock()
     mock_session.execute = AsyncMock(side_effect=[lookup, update_result, update_result])
@@ -468,6 +461,30 @@ class TestRetryProcessing:
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "indexed"
+
+    @pytest.mark.asyncio
+    @patch("d4bl.app.upload_routes.process_document_upload")
+    async def test_retry_success_preserves_existing_reviewer_notes(
+        self, mock_process, admin_client, override_db
+    ):
+        """Successful retry must not clobber notes from the initial approval."""
+        mock_process.return_value = 3
+        original_notes = "Admin approval: great source for housing equity."
+        _mock_review_lookup(
+            override_db,
+            upload_type="document",
+            status="processing_failed",
+            reviewer_notes=original_notes,
+        )
+
+        await admin_client.post(
+            "/api/admin/uploads/00000000-0000-0000-0000-000000000001/retry-processing",
+        )
+
+        # Inspect the UPDATE call — should carry original notes through.
+        update_call = override_db.execute.call_args_list[1]
+        params = update_call[0][1]
+        assert params["notes"] == original_notes
 
     @pytest.mark.asyncio
     async def test_retry_rejects_non_failed_upload(self, admin_client, override_db):

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -160,10 +160,11 @@ class TestVectorStore:
 
         self.store.generate_embedding = AsyncMock(return_value=[0.1] * 1024)
         returned_ids = [uuid4() for _ in range(3)]
+        # First call is the idempotent DELETE for this upload_id, then 3 INSERTs.
         mock_db_session.execute = AsyncMock(
             side_effect=[
-                MagicMock(scalar_one=MagicMock(return_value=rid))
-                for rid in returned_ids
+                MagicMock(),  # DELETE response (no rowcount needed)
+                *[MagicMock(scalar_one=MagicMock(return_value=rid)) for rid in returned_ids],
             ]
         )
         mock_db_session.commit = AsyncMock()
@@ -186,17 +187,47 @@ class TestVectorStore:
 
         assert result == returned_ids
         assert self.store.generate_embedding.call_count == 3
-        assert mock_db_session.execute.call_count == 3
+        # 1 DELETE + 3 INSERTs
+        assert mock_db_session.execute.call_count == 4
         mock_db_session.commit.assert_called_once()
 
-        # Inspect the first insert's metadata to confirm enrichment.
-        first_call_params = mock_db_session.execute.call_args_list[0][0][1]
-        metadata = _json.loads(first_call_params["metadata"])
+        # First execute is the DELETE — confirm it targets this upload_id.
+        delete_call_params = mock_db_session.execute.call_args_list[0][0][1]
+        assert delete_call_params == {"upload_id": str(upload_id)}
+
+        # Second execute is the first INSERT — inspect metadata enrichment.
+        first_insert_params = mock_db_session.execute.call_args_list[1][0][1]
+        metadata = _json.loads(first_insert_params["metadata"])
         assert metadata["title"] == "Overlooked: Women and Jails"
         assert metadata["upload_id"] == str(upload_id)
         assert metadata["chunk_index"] == 0
         assert metadata["total_chunks"] == 3
         assert metadata["source_type"] == "staff_upload"
+
+    @pytest.mark.asyncio
+    async def test_store_staff_document_deletes_existing_chunks_first(
+        self, mock_db_session
+    ):
+        """Idempotency: DELETE runs before any INSERT so retries don't duplicate."""
+        self.store.generate_embedding = AsyncMock(return_value=[0.1] * 1024)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(),
+                MagicMock(scalar_one=MagicMock(return_value=uuid4())),
+            ]
+        )
+        mock_db_session.commit = AsyncMock()
+
+        await self.store.store_staff_document(
+            db=mock_db_session,
+            upload_id=uuid4(),
+            chunks=["only chunk"],
+            metadata_base={"title": "Test"},
+        )
+
+        first_sql = str(mock_db_session.execute.call_args_list[0][0][0])
+        assert "DELETE FROM scraped_content_vectors" in first_sql
+        assert "'staff_upload'" in first_sql
 
     @pytest.mark.asyncio
     async def test_store_staff_document_empty_chunks_returns_empty(
@@ -242,8 +273,12 @@ class TestVectorStore:
     ):
         """URL-based uploads propagate source_url to the url column."""
         self.store.generate_embedding = AsyncMock(return_value=[0.1] * 1024)
+        # First call is DELETE, second is INSERT.
         mock_db_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one=MagicMock(return_value=uuid4()))
+            side_effect=[
+                MagicMock(),
+                MagicMock(scalar_one=MagicMock(return_value=uuid4())),
+            ]
         )
         mock_db_session.commit = AsyncMock()
 
@@ -257,8 +292,9 @@ class TestVectorStore:
             },
         )
 
-        call_params = mock_db_session.execute.call_args_list[0][0][1]
-        assert call_params["url"] == "https://propublica.org/article"
+        # INSERT is the second execute call (call_args_list[1]).
+        insert_params = mock_db_session.execute.call_args_list[1][0][1]
+        assert insert_params["url"] == "https://propublica.org/article"
 
 
 class TestHelpers:

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -151,6 +151,115 @@ class TestVectorStore:
         assert count == 2
         assert self.store.generate_embedding.call_count == 2
 
+    @pytest.mark.asyncio
+    async def test_store_staff_document_inserts_one_row_per_chunk(
+        self, mock_db_session
+    ):
+        """store_staff_document embeds and inserts one row per chunk."""
+        import json as _json
+
+        self.store.generate_embedding = AsyncMock(return_value=[0.1] * 1024)
+        returned_ids = [uuid4() for _ in range(3)]
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one=MagicMock(return_value=rid))
+                for rid in returned_ids
+            ]
+        )
+        mock_db_session.commit = AsyncMock()
+
+        upload_id = uuid4()
+        chunks = ["chunk one text", "chunk two text", "chunk three text"]
+        metadata_base = {
+            "title": "Overlooked: Women and Jails",
+            "uploader_email": "alice@d4bl.org",
+            "source_url": None,
+            "original_filename": "vera_overlooked.pdf",
+        }
+
+        result = await self.store.store_staff_document(
+            db=mock_db_session,
+            upload_id=upload_id,
+            chunks=chunks,
+            metadata_base=metadata_base,
+        )
+
+        assert result == returned_ids
+        assert self.store.generate_embedding.call_count == 3
+        assert mock_db_session.execute.call_count == 3
+        mock_db_session.commit.assert_called_once()
+
+        # Inspect the first insert's metadata to confirm enrichment.
+        first_call_params = mock_db_session.execute.call_args_list[0][0][1]
+        metadata = _json.loads(first_call_params["metadata"])
+        assert metadata["title"] == "Overlooked: Women and Jails"
+        assert metadata["upload_id"] == str(upload_id)
+        assert metadata["chunk_index"] == 0
+        assert metadata["total_chunks"] == 3
+        assert metadata["source_type"] == "staff_upload"
+
+    @pytest.mark.asyncio
+    async def test_store_staff_document_empty_chunks_returns_empty(
+        self, mock_db_session
+    ):
+        """Empty chunks list should short-circuit without DB calls."""
+        self.store.generate_embedding = AsyncMock()
+        mock_db_session.execute = AsyncMock()
+
+        result = await self.store.store_staff_document(
+            db=mock_db_session,
+            upload_id=uuid4(),
+            chunks=[],
+            metadata_base={"title": "Empty doc"},
+        )
+
+        assert result == []
+        self.store.generate_embedding.assert_not_called()
+        mock_db_session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_store_staff_document_rollback_on_error(self, mock_db_session):
+        """If any chunk fails to insert, rollback and re-raise."""
+        self.store.generate_embedding = AsyncMock(return_value=[0.1] * 1024)
+        mock_db_session.execute = AsyncMock(side_effect=RuntimeError("db down"))
+        mock_db_session.commit = AsyncMock()
+        mock_db_session.rollback = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="db down"):
+            await self.store.store_staff_document(
+                db=mock_db_session,
+                upload_id=uuid4(),
+                chunks=["only chunk"],
+                metadata_base={"title": "Test"},
+            )
+
+        mock_db_session.rollback.assert_called_once()
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_store_staff_document_uses_source_url_when_present(
+        self, mock_db_session
+    ):
+        """URL-based uploads propagate source_url to the url column."""
+        self.store.generate_embedding = AsyncMock(return_value=[0.1] * 1024)
+        mock_db_session.execute = AsyncMock(
+            return_value=MagicMock(scalar_one=MagicMock(return_value=uuid4()))
+        )
+        mock_db_session.commit = AsyncMock()
+
+        await self.store.store_staff_document(
+            db=mock_db_session,
+            upload_id=uuid4(),
+            chunks=["some content"],
+            metadata_base={
+                "title": "ProPublica investigation",
+                "source_url": "https://propublica.org/article",
+            },
+        )
+
+        call_params = mock_db_session.execute.call_args_list[0][0][1]
+        assert call_params["url"] == "https://propublica.org/article"
+
 
 class TestHelpers:
     """Tests for extracted helper methods."""

--- a/ui-nextjs/app/guide/page.tsx
+++ b/ui-nextjs/app/guide/page.tsx
@@ -87,14 +87,18 @@ export default function GuidePage() {
             <p>
               <span className="text-white font-semibold">File vs. URL:</span>{' '}
               Upload PDFs or DOCX files directly (25 MB max) for documents you have on disk.
-              For web articles and online reports, paste a URL instead — the platform will fetch
-              and extract the text automatically.
+              For web articles and online reports, paste a URL instead. In either case, the
+              platform extracts the text at submit time so the admin can review the actual
+              content — not just a link that might change later.
             </p>
             <p>
-              <span className="text-white font-semibold">How documents feed the system:</span>{' '}
-              Uploaded documents are chunked and embedded into the vector store. Research agents
-              cite them when answering queries, and they appear in vector search results on{' '}
-              <span className="text-[#00ff32]">/explore</span>.
+              <span className="text-white font-semibold">What happens after approval:</span>{' '}
+              Once an admin approves your upload, the extracted text is split into chunks,
+              embedded into the vector store, and tagged with your name as the contributor.
+              Research agents cite approved documents when answering queries, and they appear
+              in vector search results on <span className="text-[#00ff32]">/explore</span>.
+              If processing fails (rare — usually a timeout on Ollama), the admin sees the
+              error in the review queue and can retry without you needing to resubmit.
             </p>
             <p>
               <span className="text-white font-semibold">Example:</span>{' '}

--- a/ui-nextjs/components/admin/ReviewQueue.tsx
+++ b/ui-nextjs/components/admin/ReviewQueue.tsx
@@ -7,6 +7,7 @@ import ReviewDetail from './ReviewDetail';
 import type { UploadRecord } from './upload-types';
 
 type UploadTypeFilter = 'all' | 'datasource' | 'document' | 'query' | 'feature_request';
+type StatusFilter = 'pending_review' | 'processing_failed';
 
 const TYPE_LABELS: Record<string, string> = {
   datasource: 'Data Source',
@@ -15,7 +16,7 @@ const TYPE_LABELS: Record<string, string> = {
   feature_request: 'Feature Request',
 };
 
-const FILTER_OPTIONS: { value: UploadTypeFilter; label: string }[] = [
+const TYPE_OPTIONS: { value: UploadTypeFilter; label: string }[] = [
   { value: 'all', label: 'All Types' },
   { value: 'datasource', label: 'Data Sources' },
   { value: 'document', label: 'Documents' },
@@ -23,13 +24,21 @@ const FILTER_OPTIONS: { value: UploadTypeFilter; label: string }[] = [
   { value: 'feature_request', label: 'Feature Requests' },
 ];
 
+const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: 'pending_review', label: 'Pending Review' },
+  { value: 'processing_failed', label: 'Processing Failures' },
+];
+
 export default function ReviewQueue() {
   const { session } = useAuth();
   const [uploads, setUploads] = useState<UploadRecord[]>([]);
-  const [filter, setFilter] = useState<UploadTypeFilter>('all');
+  const [typeFilter, setTypeFilter] = useState<UploadTypeFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending_review');
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [retryError, setRetryError] = useState<{ id: string; message: string } | null>(null);
 
   const fetchUploads = useCallback(async () => {
     if (!session?.access_token) return;
@@ -37,8 +46,8 @@ export default function ReviewQueue() {
     setError(null);
 
     try {
-      const params = new URLSearchParams({ status: 'pending_review' });
-      if (filter !== 'all') params.append('upload_type', filter);
+      const params = new URLSearchParams({ status: statusFilter });
+      if (typeFilter !== 'all') params.append('upload_type', typeFilter);
 
       const resp = await fetch(`${API_BASE}/api/admin/uploads?${params.toString()}`, {
         headers: {
@@ -58,7 +67,7 @@ export default function ReviewQueue() {
     } finally {
       setLoading(false);
     }
-  }, [session?.access_token, filter]);
+  }, [session?.access_token, typeFilter, statusFilter]);
 
   useEffect(() => {
     fetchUploads();
@@ -69,60 +78,111 @@ export default function ReviewQueue() {
     setUploads((prev) => prev.filter((u) => u.id !== id));
   };
 
+  const handleRetry = async (id: string) => {
+    if (!session?.access_token) return;
+    setRetryingId(id);
+    setRetryError(null);
+    try {
+      const resp = await fetch(
+        `${API_BASE}/api/admin/uploads/${id}/retry-processing`,
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        }
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        if (data.status === 'indexed') {
+          setUploads((prev) => prev.filter((u) => u.id !== id));
+        } else {
+          setRetryError({ id, message: data.error || 'Retry failed.' });
+        }
+      } else {
+        const data = await resp.json().catch(() => ({}));
+        setRetryError({ id, message: data.detail || 'Retry failed.' });
+      }
+    } catch {
+      setRetryError({ id, message: 'Network error during retry.' });
+    } finally {
+      setRetryingId(null);
+    }
+  };
+
   const toggleExpand = (id: string) => {
     setExpandedId((prev) => (prev === id ? null : id));
   };
 
+  const isFailureView = statusFilter === 'processing_failed';
+
   return (
     <div>
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
         <div className="flex items-center gap-3">
           <h2 className="text-lg font-semibold text-white">Review Queue</h2>
           {!loading && (
             <span className="text-xs bg-[#404040] text-gray-300 px-2 py-1 rounded">
-              {uploads.length} pending
+              {uploads.length} {isFailureView ? 'failed' : 'pending'}
             </span>
           )}
         </div>
 
-        {/* Filter dropdown */}
-        <div>
-          <label htmlFor="review-type-filter" className="sr-only">Filter by type</label>
-          <select
-            id="review-type-filter"
-            value={filter}
-            onChange={(e) => {
-              setFilter(e.target.value as UploadTypeFilter);
-              setExpandedId(null);
-            }}
-            className="bg-[#292929] border border-[#404040] rounded px-3 py-1.5 text-sm text-white
-                       focus:outline-none focus:border-[#00ff32] transition-colors"
-          >
-            {FILTER_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+        <div className="flex gap-2">
+          <div>
+            <label htmlFor="review-status-filter" className="sr-only">Filter by status</label>
+            <select
+              id="review-status-filter"
+              value={statusFilter}
+              onChange={(e) => {
+                setStatusFilter(e.target.value as StatusFilter);
+                setExpandedId(null);
+              }}
+              className="bg-[#292929] border border-[#404040] rounded px-3 py-1.5 text-sm text-white
+                         focus:outline-none focus:border-[#00ff32] transition-colors"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="review-type-filter" className="sr-only">Filter by type</label>
+            <select
+              id="review-type-filter"
+              value={typeFilter}
+              onChange={(e) => {
+                setTypeFilter(e.target.value as UploadTypeFilter);
+                setExpandedId(null);
+              }}
+              className="bg-[#292929] border border-[#404040] rounded px-3 py-1.5 text-sm text-white
+                         focus:outline-none focus:border-[#00ff32] transition-colors"
+            >
+              {TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
 
-      {/* Loading state */}
       {loading && (
         <p className="text-sm text-gray-400 py-4">Loading...</p>
       )}
 
-      {/* Error state */}
       {error && !loading && (
         <p className="text-sm text-red-400 py-2">{error}</p>
       )}
 
-      {/* Empty state */}
       {!loading && !error && uploads.length === 0 && (
-        <p className="text-sm text-gray-500 py-4">No uploads pending review.</p>
+        <p className="text-sm text-gray-500 py-4">
+          {isFailureView ? 'No failed uploads.' : 'No uploads pending review.'}
+        </p>
       )}
 
-      {/* Upload rows */}
       {!loading && uploads.length > 0 && (
         <div className="space-y-2">
           {uploads.map((upload) => {
@@ -131,7 +191,6 @@ export default function ReviewQueue() {
 
             return (
               <div key={upload.id} className="border border-[#404040] rounded-lg overflow-hidden">
-                {/* Row header */}
                 <button
                   type="button"
                   onClick={() => toggleExpand(upload.id)}
@@ -139,12 +198,10 @@ export default function ReviewQueue() {
                              transition-colors text-left"
                   aria-expanded={isExpanded}
                 >
-                  {/* Type badge */}
                   <span className="text-xs bg-[#404040] text-gray-300 px-2 py-1 rounded flex-shrink-0">
                     {typeLabel}
                   </span>
 
-                  {/* Title / filename */}
                   <span className="flex-1 min-w-0">
                     <span className="text-white text-sm font-medium truncate block">
                       {upload.original_filename ||
@@ -160,14 +217,12 @@ export default function ReviewQueue() {
                     </span>
                   </span>
 
-                  {/* Date */}
                   <span className="text-gray-500 text-xs flex-shrink-0 hidden sm:block">
                     {upload.created_at
                       ? new Date(upload.created_at).toLocaleDateString()
                       : '—'}
                   </span>
 
-                  {/* Expand/collapse arrow */}
                   <svg
                     className={`w-4 h-4 text-gray-400 flex-shrink-0 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
                     fill="none"
@@ -179,13 +234,39 @@ export default function ReviewQueue() {
                   </svg>
                 </button>
 
-                {/* Expandable detail panel */}
                 {isExpanded && (
                   <div className="px-4 pb-4">
-                    <ReviewDetail
-                      upload={upload}
-                      onReviewed={() => handleReviewed(upload.id)}
-                    />
+                    {isFailureView ? (
+                      <div className="bg-[#222] border border-[#404040] rounded-lg p-4 mt-2 space-y-3">
+                        {upload.reviewer_notes && (
+                          <div>
+                            <p className="text-gray-500 text-xs uppercase tracking-wide mb-1">
+                              Failure reason
+                            </p>
+                            <p className="text-red-400 text-sm whitespace-pre-wrap break-words">
+                              {upload.reviewer_notes}
+                            </p>
+                          </div>
+                        )}
+                        {retryError?.id === upload.id && (
+                          <p className="text-sm text-red-400">{retryError.message}</p>
+                        )}
+                        <button
+                          type="button"
+                          disabled={retryingId === upload.id}
+                          onClick={() => handleRetry(upload.id)}
+                          className="px-4 py-2 bg-[#00ff32] text-black font-semibold rounded
+                                     hover:bg-[#00cc28] disabled:opacity-50 transition-colors text-sm"
+                        >
+                          {retryingId === upload.id ? 'Retrying...' : 'Retry processing'}
+                        </button>
+                      </div>
+                    ) : (
+                      <ReviewDetail
+                        upload={upload}
+                        onReviewed={() => handleReviewed(upload.id)}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/ui-nextjs/components/admin/UploadHistory.tsx
+++ b/ui-nextjs/components/admin/UploadHistory.tsx
@@ -16,6 +16,8 @@ const STATUS_STYLES: Record<string, string> = {
   rejected: 'bg-red-900 text-red-300 border border-red-700',
   processing: 'bg-blue-900 text-blue-300 border border-blue-700',
   live: 'bg-emerald-900 text-emerald-300 border border-emerald-600',
+  indexed: 'bg-emerald-900 text-emerald-300 border border-emerald-600',
+  processing_failed: 'bg-red-950 text-red-400 border border-red-800',
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -24,6 +26,8 @@ const STATUS_LABELS: Record<string, string> = {
   rejected: 'Rejected',
   processing: 'Processing',
   live: 'Live',
+  indexed: 'Indexed',
+  processing_failed: 'Processing Failed',
 };
 
 function getPreviewText(record: UploadRecord): string {


### PR DESCRIPTION
Closes #191

## Summary

Ships the post-approval processing pipeline for staff-contributed **documents** (PDF, DOCX, URL). When an admin approves a document in the review queue, the extracted text is chunked, embedded via Ollama, and written to the vector store alongside research-job content — which means CrewAI research agents cite approved staff documents automatically, and they surface on `/explore` vector search.

This is the feature the `/guide` page has been promising. Sections 1 and 3 of `/guide` still describe aspirational behavior and will be updated when #190 and #192 ship.

## What landed (7 milestones from the plan)

1. **Extractors, chunker, schema** — `extract_pdf`/`docx`/`url` with typed `ExtractionError`, paragraph-aware greedy chunker with character-window fallback, and a migration relaxing `scraped_content_vectors.job_id` + adding a `source` column
2. **VectorStore extension** — `store_staff_document` method embeds each chunk and inserts one row per chunk with `source='staff_upload'`; existing `store_scraped_content` explicitly sets `source='research_job'`. CHECK constraint enforces `source='research_job' → job_id IS NOT NULL`
3. **Submit-time extraction** — URL uploads fetch and extract at submit; admins review actual text, not just a link
4. **Approval processing + retry** — approving a document runs `process_document_upload` inline. On success status = `indexed`; on failure status = `processing_failed` with error in `reviewer_notes`. New `POST /api/admin/uploads/{id}/retry-processing` endpoint. File uploads also extract at submit (Milestone 4 scope expansion) so approval doesn't need the raw bytes back
5. **Admin UI** — `UploadHistory` shows `indexed`/`processing_failed` labels; `ReviewQueue` gains a status filter and retry button for failed uploads
6. **Guide copy** — Section 2 of `/guide` rewritten to describe shipped behavior
7. **Verification** — 71 tests pass across doc pipeline + related files; ruff clean; frontend build + lint green

## Design decisions (noted in the plan)

- **One table, not two.** Staff docs land in `scraped_content_vectors` with `source='staff_upload'`. Agents pick them up for free via existing retrieval. No duplicate schema.
- **Fetch URL at submit, not on approval.** Admins should approve actual content, not a link that might have changed.
- **Parse-and-discard file bytes.** Extract PDF/DOCX text at submit, store `full_text` in `metadata_` (capped at 500KB), discard the file. Supabase Storage wiring deferred.
- **Inline processing.** Admin clicks approve, waits ~10–30s for chunking + embedding, sees the result. No background worker yet — revisit when #190 makes it a third use case.
- **Reuse ExtractionError → 422, processing errors → `processing_failed` status.** Clear separation between "contributor fixable" and "infra problem."

## Test plan

Automated (already passing):
- [x] `pytest tests/test_document_processing.py` — 18 extractor/chunker/approve unit tests
- [x] `pytest tests/test_vector_store.py` — 4 new tests for `store_staff_document`
- [x] `pytest tests/test_upload_api.py` — 17 tests covering submit extraction, review flow (approve/reject/failure), retry endpoint (happy path + 400s + auth)
- [x] `ruff check src/d4bl tests` clean
- [x] `npm run lint` — no new warnings
- [x] `npm run build` — `/guide`, `/admin` routes static

Manual QA before merge:
- [ ] Apply `supabase/migrations/20260418000000_staff_documents_vectors.sql` to a dev DB and confirm no error inserting a research-job row
- [ ] Upload a real PDF in `/admin`, approve it, run a research query, confirm the approved document is cited
- [ ] Upload a URL, confirm preview text populates in admin review
- [ ] Force a failure (e.g., stop Ollama), approve, confirm `processing_failed` state with retry button
- [ ] Click retry after Ollama comes back, confirm state flips to `indexed`

## Schema change

`scraped_content_vectors`:
- `job_id` → nullable (was `NOT NULL`)
- `source VARCHAR(30) NOT NULL DEFAULT 'research_job'` (new column)
- `CHECK (source <> 'research_job' OR job_id IS NOT NULL)` (new constraint)

Existing rows keep `source = 'research_job'` via the default. No data migration needed.

## Out of scope

- Supabase Storage for raw file persistence
- Background worker / queue for long-running processing
- OCR for image-based PDFs
- URL document re-crawl on a schedule
- `/explore` "Staff uploads only" filter (base integration ships; filter deferred pending user feedback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff document uploads are extracted, chunked, embedded and indexed at approval; admin retry endpoint and UI controls for retrying failed processing; new upload statuses visible in history and filters.
* **Bug Fixes**
  * Extraction failures return 422 and surface error details to reviewers; approval failures mark processing_failed without losing reviewer notes.
* **Documentation**
  * Added plan and updated guide describing post-approval indexing and failure handling.
* **Tests**
  * New tests for extraction, chunking, processing, API flows, and vector store.
* **Chores**
  * Added DOCX and test-PDF dependencies; DB migrations to support staff uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->