### PR TITLE
feat: feed approved example queries into training and Explore templates (#192)

### DIFF
--- a/scripts/add_job_id_to_evaluations.py
+++ b/scripts/add_job_id_to_evaluations.py
@@ -28,8 +28,8 @@ async def add_job_id_column():
         async with db.engine.begin() as conn:
             # Check if column already exists
             check_query = text("""
-                SELECT column_name 
-                FROM information_schema.columns 
+                SELECT column_name
+                FROM information_schema.columns
                 WHERE table_name='evaluation_results' AND column_name='job_id';
             """)
             result = await conn.execute(check_query)
@@ -41,7 +41,7 @@ async def add_job_id_column():
 
             # Add the column
             alter_query = text("""
-                ALTER TABLE evaluation_results 
+                ALTER TABLE evaluation_results
                 ADD COLUMN job_id UUID REFERENCES research_jobs(job_id);
             """)
             await conn.execute(alter_query)
@@ -49,7 +49,7 @@ async def add_job_id_column():
 
             # Create index for better query performance
             index_query = text("""
-                CREATE INDEX IF NOT EXISTS idx_evaluation_results_job_id 
+                CREATE INDEX IF NOT EXISTS idx_evaluation_results_job_id
                 ON evaluation_results(job_id);
             """)
             await conn.execute(index_query)

--- a/scripts/add_research_data_column.py
+++ b/scripts/add_research_data_column.py
@@ -41,8 +41,8 @@ async def add_research_data_column():
         async with engine.begin() as conn:
             # Check if column already exists
             check_query = text("""
-                SELECT column_name 
-                FROM information_schema.columns 
+                SELECT column_name
+                FROM information_schema.columns
                 WHERE table_name='research_jobs' AND column_name='research_data'
             """)
             result = await conn.execute(check_query)
@@ -54,7 +54,7 @@ async def add_research_data_column():
             
             # Add the column
             alter_query = text("""
-                ALTER TABLE research_jobs 
+                ALTER TABLE research_jobs
                 ADD COLUMN research_data JSON
             """)
             await conn.execute(alter_query)

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -82,7 +82,7 @@ def main():
         print("STAGE 2: Claude Distillation")
         print("=" * 60)
         from scripts.training.generate_training_pairs import main as distill_main
-        distill_main(task=args.task)
+        distill_main(task=args.task, include_approved_example_queries=True)
 
     if args.stage in ("prepare", "all"):
         print("\n" + "=" * 60)

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -91,7 +91,10 @@ def main():
         print("STAGE 2: Claude Distillation")
         print("=" * 60)
         from scripts.training.generate_training_pairs import main as distill_main
-        distill_main(task=args.task, include_approved_example_queries=args.include_approved_example_queries)
+        distill_main(
+            task=args.task,
+            include_approved_example_queries=args.include_approved_example_queries,
+        )
 
     if args.stage in ("prepare", "all"):
         print("\n" + "=" * 60)

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -44,6 +44,15 @@ def main():
     )
     parser.add_argument("--max-per-table", type=_positive_int, default=10_000)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--include-approved-example-queries",
+        action="store_true",
+        default=False,
+        help=(
+            "Merge approved staff example queries into query_parser and "
+            "query_parser_v2 distill runs (writes sidecar JSON for --resume)."
+        ),
+    )
     args = parser.parse_args()
 
     # v2/v3 tasks map to their base task for the prepare stage
@@ -82,7 +91,7 @@ def main():
         print("STAGE 2: Claude Distillation")
         print("=" * 60)
         from scripts.training.generate_training_pairs import main as distill_main
-        distill_main(task=args.task, include_approved_example_queries=True)
+        distill_main(task=args.task, include_approved_example_queries=args.include_approved_example_queries)
 
     if args.stage in ("prepare", "all"):
         print("\n" + "=" * 60)

--- a/scripts/training/extract_corpus.py
+++ b/scripts/training/extract_corpus.py
@@ -19,6 +19,7 @@ from scripts.training.templates import (
     render_census_passage,
     render_document_passage,
     render_epa_passage,
+    render_example_query_passage,
     render_fbi_passage,
     render_police_violence_passage,
 )
@@ -96,6 +97,17 @@ EXTRACTORS: dict[str, dict[str, Any]] = {
         ),
         "template": render_document_passage,
     },
+    "approved_example_queries": {
+        "query": (
+            "SELECT eq.query_text, eq.description "
+            "FROM example_queries eq "
+            "INNER JOIN uploads u ON u.id = eq.upload_id "
+            "WHERE u.upload_type = 'query' AND u.status = 'approved' "
+            "ORDER BY u.reviewed_at DESC NULLS LAST, eq.created_at DESC "
+            "LIMIT %(limit)s"
+        ),
+        "template": render_example_query_passage,
+    },
 }
 
 
@@ -172,7 +184,17 @@ def main(tables: list[str] | None = None, max_per_table: int = MAX_PASSAGES_PER_
     try:
         for table in target_tables:
             logger.info("Extracting %s (max %d rows)…", table, max_per_table)
-            passages = extract_table(conn, table, max_per_table)
+            try:
+                passages = extract_table(conn, table, max_per_table)
+            except Exception as exc:  # noqa: BLE001
+                if table == "approved_example_queries":
+                    logger.warning(
+                        "Skipping approved example queries (tables may be absent): %s",
+                        exc,
+                    )
+                    passages = []
+                else:
+                    raise
             outfile = CORPUS_DIR / f"{table}.jsonl"
             count = write_passages_jsonl(passages, outfile)
             logger.info("  Wrote %d passages → %s", count, outfile)

--- a/scripts/training/extract_corpus.py
+++ b/scripts/training/extract_corpus.py
@@ -178,9 +178,9 @@ def main(tables: list[str] | None = None, max_per_table: int = MAX_PASSAGES_PER_
     for t in skipped:
         logger.warning("Unknown table %r — skipping.", t)
 
-    from scripts.ingestion.helpers import get_db_connection
-
     import psycopg2.errors  # lazy — same dependency path as extract_table
+
+    from scripts.ingestion.helpers import get_db_connection
 
     conn = get_db_connection()
     try:

--- a/scripts/training/extract_corpus.py
+++ b/scripts/training/extract_corpus.py
@@ -180,13 +180,15 @@ def main(tables: list[str] | None = None, max_per_table: int = MAX_PASSAGES_PER_
 
     from scripts.ingestion.helpers import get_db_connection
 
+    import psycopg2.errors  # lazy — same dependency path as extract_table
+
     conn = get_db_connection()
     try:
         for table in target_tables:
             logger.info("Extracting %s (max %d rows)…", table, max_per_table)
             try:
                 passages = extract_table(conn, table, max_per_table)
-            except Exception as exc:  # noqa: BLE001
+            except psycopg2.errors.UndefinedTable as exc:
                 if table == "approved_example_queries":
                     logger.warning(
                         "Skipping approved example queries (tables may be absent): %s",

--- a/scripts/training/generate_training_pairs.py
+++ b/scripts/training/generate_training_pairs.py
@@ -5,11 +5,13 @@ distilling responses from a large Claude model (teacher) into a format
 suitable for training a smaller model (student).
 
 Supported tasks:
-  - query_parser: NL question → structured JSON parse
+  - query_parser: NL question → structured JSON parse (includes approved staff
+    example queries from ``example_queries`` when present)
   - explainer: Census/health data → structured narrative explanation
   - evaluator: (context, output) → evaluation judgment
   - evaluator_v2: Perturbation-based hallucination + tiered quality
-  - query_parser_v2: Entity-type-diverse question parsing
+  - query_parser_v2: Entity-type-diverse question parsing (approved staff queries
+    are injected into the intersectional batch when available)
   - evaluator_v3: Document-chunk hallucination detection
   - query_parser_v3: Community framing question parsing
 
@@ -24,11 +26,15 @@ from __future__ import annotations
 import argparse
 import functools
 import json
+import logging
 import os
 import random
 import time
+from collections import deque
 from pathlib import Path
 from typing import IO, Any, Union
+
+logger = logging.getLogger(__name__)
 
 from scripts.training.config import (
     COMMUNITY_FRAMING_PAIRS,
@@ -849,6 +855,22 @@ def generate_query_parser_pairs_v2(
 
     task_name = TASK_QUERY_PARSER_V2
 
+    staff_for_v2 = deque(
+        {
+            "question": (r.get("query_text") or "").strip(),
+            "entity_type": "intersectional",
+            "seed_data": r,
+        }
+        for r in fetch_approved_example_queries(conn, limit=400)
+        if (r.get("query_text") or "").strip()
+    )
+    if staff_for_v2:
+        print(
+            f"[{task_name}] {len(staff_for_v2)} approved staff queries available "
+            "for intersectional batch injection",
+            flush=True,
+        )
+
     if not resume:
         _clear_checkpoint(task_name, checkpoint_dir=checkpoint_dir)
 
@@ -873,6 +895,11 @@ def generate_query_parser_pairs_v2(
             questions = generate_query_parser_questions_v2(
                 seed_rows, count=type_count, entity_type=entity_type,
             )
+            if entity_type == "intersectional" and staff_for_v2:
+                n_take = min(len(staff_for_v2), max(1, type_count // 5))
+                injected = [staff_for_v2.popleft() for _ in range(n_take)]
+                tail = max(0, type_count - len(injected))
+                questions = injected + questions[:tail]
             for idx, q in enumerate(questions):
                 if resume and idx <= cp["last_attempted_idx"]:
                     continue
@@ -1233,6 +1260,78 @@ def _validate_json(text: str) -> dict | None:
     return obj
 
 
+def fetch_approved_example_queries(conn: Any, *, limit: int = 500) -> list[dict]:
+    """Load contributor example queries that passed admin review.
+
+    Returns rows with query_text, description, summary_format, and optional
+    curated_answer / relevant_sources. Empty list if tables are missing or on error.
+    """
+    import psycopg2.errors
+    import psycopg2.extras
+
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT eq.query_text, eq.description, eq.summary_format,
+                       eq.curated_answer, eq.relevant_sources
+                FROM example_queries eq
+                INNER JOIN uploads u ON u.id = eq.upload_id
+                WHERE u.upload_type = 'query' AND u.status = 'approved'
+                ORDER BY u.reviewed_at DESC NULLS LAST, eq.created_at DESC
+                LIMIT %s
+                """,
+                (limit,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+    except psycopg2.errors.UndefinedTable:
+        logger.warning(
+            "example_queries / uploads tables missing — skip approved query seeds",
+        )
+        return []
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not load approved example queries: %s", exc)
+        return []
+
+
+def merge_staff_example_queries_for_parser(
+    seed_rows: list[dict],
+    total_count: int,
+    staff_rows: list[dict],
+) -> list[dict]:
+    """Build query-parser distillation questions: approved staff first, then synthetic.
+
+    Staff-submitted questions use the *community* style in the teacher prompt to
+    match organizer-voiced language.
+    """
+    if total_count <= 0:
+        return []
+
+    staff_questions: list[dict] = []
+    for row in staff_rows:
+        text = (row.get("query_text") or "").strip()
+        if not text:
+            continue
+        staff_questions.append(
+            {
+                "question": text,
+                "style": "community",
+                "seed_data": {
+                    "source": "staff_example_query",
+                    "description": row.get("description"),
+                    "summary_format": row.get("summary_format"),
+                },
+            },
+        )
+
+    staff_questions = staff_questions[:total_count]
+    remainder = max(0, total_count - len(staff_questions))
+    synthetic = (
+        generate_query_parser_questions(seed_rows, count=remainder) if remainder else []
+    )
+    return staff_questions + synthetic
+
+
 def generate_query_parser_questions(
     seed_rows: list[dict],
     count: int,
@@ -1456,7 +1555,16 @@ def generate_query_parser_pairs(
         return []
 
     seed_rows = _load_seed_rows(conn)
-    questions = generate_query_parser_questions(seed_rows, count=count)
+    staff_rows = fetch_approved_example_queries(conn, limit=max(count, 200))
+    questions = merge_staff_example_queries_for_parser(seed_rows, count, staff_rows)
+    n_staff_merged = sum(
+        1 for q in questions if q.get("seed_data", {}).get("source") == "staff_example_query"
+    )
+    if n_staff_merged:
+        print(
+            f"[query_parser] {n_staff_merged} approved staff example queries in distill batch",
+            flush=True,
+        )
 
     data_sources = list(_ALLOWED_SEED_TABLES)
     pairs: list[dict] = []

--- a/scripts/training/generate_training_pairs.py
+++ b/scripts/training/generate_training_pairs.py
@@ -856,13 +856,15 @@ def generate_query_parser_pairs_v2(
     task_name = TASK_QUERY_PARSER_V2
 
     staff_for_v2 = deque(
-        {
-            "question": (r.get("query_text") or "").strip(),
-            "entity_type": "intersectional",
-            "seed_data": r,
-        }
-        for r in fetch_approved_example_queries(conn, limit=400)
-        if (r.get("query_text") or "").strip()
+        (
+            {
+                "question": text,
+                "entity_type": "intersectional",
+                "seed_data": r,
+            }
+            for r in fetch_approved_example_queries(conn, limit=400)
+            if (text := (r.get("query_text") or "").strip())
+        ),
     )
     if staff_for_v2:
         print(
@@ -1269,20 +1271,18 @@ def fetch_approved_example_queries(conn: Any, *, limit: int = 500) -> list[dict]
     import psycopg2.errors
     import psycopg2.extras
 
+    sql = """
+        SELECT eq.query_text, eq.description, eq.summary_format,
+               eq.curated_answer, eq.relevant_sources
+        FROM example_queries eq
+        INNER JOIN uploads u ON u.id = eq.upload_id
+        WHERE u.upload_type = 'query' AND u.status = 'approved'
+        ORDER BY u.reviewed_at DESC NULLS LAST, eq.created_at DESC
+        LIMIT %s
+    """
     try:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            cur.execute(
-                """
-                SELECT eq.query_text, eq.description, eq.summary_format,
-                       eq.curated_answer, eq.relevant_sources
-                FROM example_queries eq
-                INNER JOIN uploads u ON u.id = eq.upload_id
-                WHERE u.upload_type = 'query' AND u.status = 'approved'
-                ORDER BY u.reviewed_at DESC NULLS LAST, eq.created_at DESC
-                LIMIT %s
-                """,
-                (limit,),
-            )
+            cur.execute(sql, (limit,))
             return [dict(r) for r in cur.fetchall()]
     except psycopg2.errors.UndefinedTable:
         logger.warning(
@@ -1309,6 +1309,8 @@ def merge_staff_example_queries_for_parser(
 
     staff_questions: list[dict] = []
     for row in staff_rows:
+        if len(staff_questions) >= total_count:
+            break
         text = (row.get("query_text") or "").strip()
         if not text:
             continue
@@ -1324,8 +1326,7 @@ def merge_staff_example_queries_for_parser(
             },
         )
 
-    staff_questions = staff_questions[:total_count]
-    remainder = max(0, total_count - len(staff_questions))
+    remainder = total_count - len(staff_questions)
     synthetic = (
         generate_query_parser_questions(seed_rows, count=remainder) if remainder else []
     )
@@ -1558,7 +1559,7 @@ def generate_query_parser_pairs(
     staff_rows = fetch_approved_example_queries(conn, limit=max(count, 200))
     questions = merge_staff_example_queries_for_parser(seed_rows, count, staff_rows)
     n_staff_merged = sum(
-        1 for q in questions if q.get("seed_data", {}).get("source") == "staff_example_query"
+        q.get("seed_data", {}).get("source") == "staff_example_query" for q in questions
     )
     if n_staff_merged:
         print(

--- a/scripts/training/generate_training_pairs.py
+++ b/scripts/training/generate_training_pairs.py
@@ -802,7 +802,7 @@ def generate_query_parser_pairs_v2(
     *,
     resume: bool = False,
     checkpoint_dir: Path | None = None,
-    include_approved_example_queries: bool = True,
+    include_approved_example_queries: bool = False,
 ) -> list[dict]:
     """Generate v2 query parser pairs targeting diverse entity types.
 
@@ -869,14 +869,20 @@ def generate_query_parser_pairs_v2(
     effective_resume = resume and any(cp["last_attempted_idx"] >= 0 for cp in entity_cps.values())
 
     if include_approved_example_queries:
-        if effective_resume and staff_snap.exists():
+        if effective_resume:
+            if not staff_snap.exists():
+                raise RuntimeError(
+                    f"{task_name}: --resume with --include-approved-example-queries requires "
+                    f"{staff_snap.name} from the initial run.",
+                )
             try:
                 raw = json.loads(staff_snap.read_text(encoding="utf-8"))
                 staff_for_v2 = deque(raw if isinstance(raw, list) else [])
             except (OSError, json.JSONDecodeError) as exc:
-                logger.warning("Could not read v2 staff snapshot; continuing without: %s", exc)
-                staff_for_v2 = deque()
-        elif not effective_resume:
+                raise RuntimeError(
+                    f"{task_name}: could not read {staff_snap.name}; cannot resume safely.",
+                ) from exc
+        else:
             staff_for_v2 = deque(
                 (
                     {
@@ -896,13 +902,6 @@ def generate_query_parser_pairs_v2(
                     )
                 except OSError as exc:
                     logger.warning("Could not write v2 staff snapshot: %s", exc)
-        else:
-            staff_for_v2 = deque()
-            logger.info(
-                "[%s] Resuming without %s — intersectional staff injection skipped.",
-                task_name,
-                staff_snap.name,
-            )
     else:
         staff_for_v2 = deque()
 
@@ -1560,7 +1559,7 @@ def generate_query_parser_pairs(
     *,
     resume: bool = False,
     checkpoint_dir: Path | None = None,
-    include_approved_example_queries: bool = True,
+    include_approved_example_queries: bool = False,
 ) -> list[dict]:
     """Generate query parser training pairs via Claude distillation.
 
@@ -1574,9 +1573,10 @@ def generate_query_parser_pairs(
             progress survives interruption.
         resume: If True, resume from the last checkpoint.
         checkpoint_dir: Directory for checkpoint file. Defaults to PAIRS_DIR.
-        include_approved_example_queries: When True (default), prepend approved
-            staff queries; persisted to a sidecar JSON while resuming so indices
-            stay aligned with the initial run.
+        include_approved_example_queries: When True, prepend approved staff
+            queries; persisted to a sidecar JSON while resuming so indices stay
+            aligned with the initial run. Default False (opt-in via CLI or
+            ``run_training_pipeline``).
 
     Returns:
         A list of ChatML pair dicts.
@@ -1600,14 +1600,20 @@ def generate_query_parser_pairs(
     seed_rows = _load_seed_rows(conn)
 
     if include_approved_example_queries:
-        if effective_resume and staff_snapshot.exists():
+        if effective_resume:
+            if not staff_snapshot.exists():
+                raise RuntimeError(
+                    f"{task_name}: --resume with --include-approved-example-queries requires "
+                    f"{staff_snapshot.name} from the initial run.",
+                )
             try:
                 raw = json.loads(staff_snapshot.read_text(encoding="utf-8"))
                 staff_rows = raw if isinstance(raw, list) else []
             except (OSError, json.JSONDecodeError) as exc:
-                logger.warning("Could not read staff snapshot; continuing without: %s", exc)
-                staff_rows = []
-        elif not effective_resume:
+                raise RuntimeError(
+                    f"{task_name}: could not read {staff_snapshot.name}; cannot resume safely.",
+                ) from exc
+        else:
             staff_rows = fetch_approved_example_queries(conn, limit=max(count, 200))
             if staff_rows:
                 try:
@@ -1617,13 +1623,6 @@ def generate_query_parser_pairs(
                     )
                 except OSError as exc:
                     logger.warning("Could not write staff snapshot: %s", exc)
-        else:
-            staff_rows = []
-            logger.info(
-                "[%s] Resuming without %s — approved staff prefix unavailable for this run.",
-                task_name,
-                staff_snapshot.name,
-            )
     else:
         staff_rows = []
 
@@ -1902,19 +1901,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Resume from checkpoint instead of starting fresh.",
     )
     parser.add_argument(
-        "--no-include-approved-example-queries",
-        action="store_false",
-        dest="include_approved_example_queries",
-        default=True,
+        "--include-approved-example-queries",
+        action="store_true",
+        default=False,
         help=(
-            "Disable merging approved staff example queries into query_parser and "
-            "query_parser_v2 distill runs."
+            "Merge approved staff example queries into query_parser and "
+            "query_parser_v2 distill runs (writes sidecar JSON for --resume)."
         ),
     )
     return parser
 
 
-def main(task: str, *, resume: bool = False, include_approved_example_queries: bool = True) -> None:
+def main(task: str, *, resume: bool = False, include_approved_example_queries: bool = False) -> None:
     """Run the selected task generator and write pairs to PAIRS_DIR.
 
     Args:

--- a/scripts/training/generate_training_pairs.py
+++ b/scripts/training/generate_training_pairs.py
@@ -802,6 +802,7 @@ def generate_query_parser_pairs_v2(
     *,
     resume: bool = False,
     checkpoint_dir: Path | None = None,
+    include_approved_example_queries: bool = True,
 ) -> list[dict]:
     """Generate v2 query parser pairs targeting diverse entity types.
 
@@ -814,6 +815,8 @@ def generate_query_parser_pairs_v2(
         outfile: Optional output path for incremental writes.
         resume: If True, resume from the last checkpoint per entity type.
         checkpoint_dir: Directory for checkpoint file. Defaults to PAIRS_DIR.
+        include_approved_example_queries: When True, inject approved staff queries
+            into the intersectional batch; order is snapshotted for ``--resume``.
 
     Returns:
         A list of ChatML pair dicts.
@@ -854,31 +857,61 @@ def generate_query_parser_pairs_v2(
     pairs: list[dict] = []
 
     task_name = TASK_QUERY_PARSER_V2
-
-    staff_for_v2 = deque(
-        (
-            {
-                "question": text,
-                "entity_type": "intersectional",
-                "seed_data": r,
-            }
-            for r in fetch_approved_example_queries(conn, limit=400)
-            if (text := (r.get("query_text") or "").strip())
-        ),
-    )
-    if staff_for_v2:
-        print(
-            f"[{task_name}] {len(staff_for_v2)} approved staff queries available "
-            "for intersectional batch injection",
-            flush=True,
-        )
+    cp_dir = checkpoint_dir or PAIRS_DIR
+    staff_snap = cp_dir / ".query_parser_v2_staff_snapshot.json"
 
     if not resume:
         _clear_checkpoint(task_name, checkpoint_dir=checkpoint_dir)
+        staff_snap.unlink(missing_ok=True)
 
     # Guard against stale output when checkpoint is missing/empty but resume=True
     entity_cps = {et: _load_checkpoint(task_name, et, checkpoint_dir=checkpoint_dir) for et in type_counts}
     effective_resume = resume and any(cp["last_attempted_idx"] >= 0 for cp in entity_cps.values())
+
+    if include_approved_example_queries:
+        if effective_resume and staff_snap.exists():
+            try:
+                raw = json.loads(staff_snap.read_text(encoding="utf-8"))
+                staff_for_v2 = deque(raw if isinstance(raw, list) else [])
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("Could not read v2 staff snapshot; continuing without: %s", exc)
+                staff_for_v2 = deque()
+        elif not effective_resume:
+            staff_for_v2 = deque(
+                (
+                    {
+                        "question": text,
+                        "entity_type": "intersectional",
+                        "seed_data": r,
+                    }
+                    for r in fetch_approved_example_queries(conn, limit=400)
+                    if (text := (r.get("query_text") or "").strip())
+                ),
+            )
+            if staff_for_v2:
+                try:
+                    staff_snap.write_text(
+                        json.dumps(list(staff_for_v2), ensure_ascii=False, default=str),
+                        encoding="utf-8",
+                    )
+                except OSError as exc:
+                    logger.warning("Could not write v2 staff snapshot: %s", exc)
+        else:
+            staff_for_v2 = deque()
+            logger.info(
+                "[%s] Resuming without %s — intersectional staff injection skipped.",
+                task_name,
+                staff_snap.name,
+            )
+    else:
+        staff_for_v2 = deque()
+
+    if staff_for_v2:
+        print(
+            f"[{task_name}] {len(staff_for_v2)} approved staff queries staged "
+            "for intersectional batch injection",
+            flush=True,
+        )
 
     fh = _open_incremental_writer(outfile, resume=effective_resume)
     pair_count = 0
@@ -1527,6 +1560,7 @@ def generate_query_parser_pairs(
     *,
     resume: bool = False,
     checkpoint_dir: Path | None = None,
+    include_approved_example_queries: bool = True,
 ) -> list[dict]:
     """Generate query parser training pairs via Claude distillation.
 
@@ -1540,23 +1574,59 @@ def generate_query_parser_pairs(
             progress survives interruption.
         resume: If True, resume from the last checkpoint.
         checkpoint_dir: Directory for checkpoint file. Defaults to PAIRS_DIR.
+        include_approved_example_queries: When True (default), prepend approved
+            staff queries; persisted to a sidecar JSON while resuming so indices
+            stay aligned with the initial run.
 
     Returns:
         A list of ChatML pair dicts.
     """
     task_name = TASK_QUERY_PARSER
     subtask = "_default"
+    cp_dir = checkpoint_dir or PAIRS_DIR
+    staff_snapshot = cp_dir / ".query_parser_staff_snapshot.json"
 
     if not resume:
         _clear_checkpoint(task_name, checkpoint_dir=checkpoint_dir)
+        staff_snapshot.unlink(missing_ok=True)
 
     cp = _load_checkpoint(task_name, subtask, checkpoint_dir=checkpoint_dir)
     if resume and cp["status"] == "completed":
         print(f"[{task_name}] Already completed — skipping", flush=True)
         return []
 
+    effective_resume = resume and cp["last_attempted_idx"] >= 0
+
     seed_rows = _load_seed_rows(conn)
-    staff_rows = fetch_approved_example_queries(conn, limit=max(count, 200))
+
+    if include_approved_example_queries:
+        if effective_resume and staff_snapshot.exists():
+            try:
+                raw = json.loads(staff_snapshot.read_text(encoding="utf-8"))
+                staff_rows = raw if isinstance(raw, list) else []
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("Could not read staff snapshot; continuing without: %s", exc)
+                staff_rows = []
+        elif not effective_resume:
+            staff_rows = fetch_approved_example_queries(conn, limit=max(count, 200))
+            if staff_rows:
+                try:
+                    staff_snapshot.write_text(
+                        json.dumps(staff_rows, ensure_ascii=False, default=str),
+                        encoding="utf-8",
+                    )
+                except OSError as exc:
+                    logger.warning("Could not write staff snapshot: %s", exc)
+        else:
+            staff_rows = []
+            logger.info(
+                "[%s] Resuming without %s — approved staff prefix unavailable for this run.",
+                task_name,
+                staff_snapshot.name,
+            )
+    else:
+        staff_rows = []
+
     questions = merge_staff_example_queries_for_parser(seed_rows, count, staff_rows)
     n_staff_merged = sum(
         q.get("seed_data", {}).get("source") == "staff_example_query" for q in questions
@@ -1571,7 +1641,6 @@ def generate_query_parser_pairs(
     pairs: list[dict] = []
 
     # Guard against stale output when checkpoint is missing/empty but resume=True
-    effective_resume = resume and cp["last_attempted_idx"] >= 0
     fh = _open_incremental_writer(outfile, resume=effective_resume)
     pair_count = cp["pairs_written"] if effective_resume else 0
 
@@ -1832,10 +1901,20 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=False,
         help="Resume from checkpoint instead of starting fresh.",
     )
+    parser.add_argument(
+        "--no-include-approved-example-queries",
+        action="store_false",
+        dest="include_approved_example_queries",
+        default=True,
+        help=(
+            "Disable merging approved staff example queries into query_parser and "
+            "query_parser_v2 distill runs."
+        ),
+    )
     return parser
 
 
-def main(task: str, *, resume: bool = False) -> None:
+def main(task: str, *, resume: bool = False, include_approved_example_queries: bool = True) -> None:
     """Run the selected task generator and write pairs to PAIRS_DIR.
 
     Args:
@@ -1874,10 +1953,12 @@ def main(task: str, *, resume: bool = False) -> None:
     try:
         PAIRS_DIR.mkdir(parents=True, exist_ok=True)
 
+        inc = include_approved_example_queries
         _TASK_MAP = {
             "query_parser": lambda: generate_query_parser_pairs(
                 conn, count=PAIRS_PER_TASK, outfile=PAIRS_DIR / "query_parser.jsonl",
                 resume=resume,
+                include_approved_example_queries=inc,
             ),
             "explainer": lambda: generate_explainer_pairs(
                 conn, count=PAIRS_PER_TASK, outfile=PAIRS_DIR / "explainer.jsonl",
@@ -1897,6 +1978,7 @@ def main(task: str, *, resume: bool = False) -> None:
                 conn, count=PARSER_V2_ENTITY_PAIRS,
                 outfile=PAIRS_DIR / "query_parser_v2.jsonl",
                 resume=resume,
+                include_approved_example_queries=inc,
             ),
             "evaluator_v3": lambda: generate_doc_hallucination_pairs(
                 conn, count_per_subtask=DOC_EVALUATOR_PAIRS_PER_SUBTASK,
@@ -1948,4 +2030,8 @@ def main(task: str, *, resume: bool = False) -> None:
 if __name__ == "__main__":
     _parser = _build_arg_parser()
     _args = _parser.parse_args()
-    main(_args.task, resume=_args.resume)
+    main(
+        _args.task,
+        resume=_args.resume,
+        include_approved_example_queries=_args.include_approved_example_queries,
+    )

--- a/scripts/training/migrate_documents.py
+++ b/scripts/training/migrate_documents.py
@@ -18,7 +18,6 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime, timezone
 from typing import Any
 
 import psycopg2

--- a/scripts/training/run_eval_harness.py
+++ b/scripts/training/run_eval_harness.py
@@ -12,7 +12,6 @@ import argparse
 import asyncio
 import hashlib
 import logging
-import re
 import sys
 import time
 from dataclasses import asdict, dataclass

--- a/scripts/training/templates.py
+++ b/scripts/training/templates.py
@@ -251,3 +251,20 @@ def render_document_passage(row: dict) -> str:
         header += f' — "{title}"'
 
     return f"{header}\n{content}"
+
+
+def render_example_query_passage(row: dict) -> str:
+    """Render an approved staff example query as a short pretraining passage.
+
+    Expected keys: query_text, description (optional).
+    """
+    query_text = (row.get("query_text") or "").strip()
+    if not query_text:
+        return ""
+    desc = (row.get("description") or "").strip()
+    if desc:
+        return (
+            f"Example equity research question: {query_text}\n\n"
+            f"Contributor framing: {desc}"
+        )
+    return f"Example equity research question: {query_text}"

--- a/scripts/training/templates.py
+++ b/scripts/training/templates.py
@@ -262,9 +262,7 @@ def render_example_query_passage(row: dict) -> str:
     if not query_text:
         return ""
     desc = (row.get("description") or "").strip()
-    if desc:
-        return (
-            f"Example equity research question: {query_text}\n\n"
-            f"Contributor framing: {desc}"
-        )
-    return f"Example equity research question: {query_text}"
+    lead = f"Example equity research question: {query_text}"
+    if not desc:
+        return lead
+    return f"{lead}\n\nContributor framing: {desc}"

--- a/scripts/training/train.py
+++ b/scripts/training/train.py
@@ -20,7 +20,6 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-import unsloth  # must be imported before transformers/trl/peft
 import torch
 from datasets import Dataset
 from huggingface_hub import login
@@ -673,7 +672,7 @@ def run_health_checks(phase_name: str, stats: dict) -> dict[str, dict]:
         else:
             checks["eval_trend"] = {
                 "status": "warn",
-                "message": f"eval_loss rising over last 3 checkpoints: {[f'{l:.3f}' for l in last3]}",
+                "message": f"eval_loss rising over last 3 checkpoints: {[f'{loss:.3f}' for loss in last3]}",
             }
 
     return checks
@@ -811,7 +810,7 @@ def generate_report(output_dir: Path, telemetry: dict) -> None:
 
         eval_ckpts = p.get("eval_checkpoints", [])
         if eval_ckpts:
-            ckpt_strs = [f"{l:.3f}" for l in eval_ckpts]
+            ckpt_strs = [f"{loss:.3f}" for loss in eval_ckpts]
             lines.append(f"- **Eval checkpoints:** [{', '.join(ckpt_strs)}]")
 
         duration = p.get("duration_seconds", 0)

--- a/scripts/training/train.py
+++ b/scripts/training/train.py
@@ -670,9 +670,10 @@ def run_health_checks(phase_name: str, stats: dict) -> dict[str, dict]:
         if last3[-1] <= last3[0]:
             checks["eval_trend"] = {"status": "pass", "message": "eval_loss trending down"}
         else:
+            formatted_last3 = [f'{loss:.3f}' for loss in last3]
             checks["eval_trend"] = {
                 "status": "warn",
-                "message": f"eval_loss rising over last 3 checkpoints: {[f'{loss:.3f}' for loss in last3]}",
+                "message": f"eval_loss rising over last 3 checkpoints: {formatted_last3}",
             }
 
     return checks

--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -1876,17 +1876,24 @@ async def list_example_query_templates(
     db: AsyncSession = Depends(get_db),
 ):
     """List approved staff-submitted example queries for Explore NL templates."""
-    result = await db.execute(
-        text("""
-            SELECT eq.id, eq.query_text, eq.description, eq.summary_format
-            FROM example_queries eq
-            INNER JOIN uploads u ON u.id = eq.upload_id
-            WHERE u.upload_type = 'query' AND u.status = 'approved'
-            ORDER BY u.reviewed_at DESC NULLS LAST, eq.created_at DESC
-            LIMIT 50
-        """)
-    )
-    rows = result.mappings().all()
+    try:
+        result = await db.execute(
+            text("""
+                SELECT eq.id, eq.query_text, eq.description, eq.summary_format
+                FROM example_queries eq
+                INNER JOIN uploads u ON u.id = eq.upload_id
+                WHERE u.upload_type = 'query' AND u.status = 'approved'
+                ORDER BY u.reviewed_at DESC NULLS LAST, eq.created_at DESC
+                LIMIT 50
+            """)
+        )
+        rows = result.mappings().all()
+    except Exception:
+        logger.warning(
+            "example_query_templates: returning empty list (schema or DB error)",
+            exc_info=True,
+        )
+        return []
     return [
         {
             "id": str(r["id"]),

--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -1870,6 +1870,34 @@ async def list_staff_upload_datasets(
     return out
 
 
+@app.get("/api/explore/example-query-templates")
+async def list_example_query_templates(
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List approved staff-submitted example queries for Explore NL templates."""
+    result = await db.execute(
+        text("""
+            SELECT eq.id, eq.query_text, eq.description, eq.summary_format
+            FROM example_queries eq
+            INNER JOIN uploads u ON u.id = eq.upload_id
+            WHERE u.upload_type = 'query' AND u.status = 'approved'
+            ORDER BY u.reviewed_at DESC NULLS LAST, eq.created_at DESC
+            LIMIT 50
+        """)
+    )
+    rows = result.mappings().all()
+    return [
+        {
+            "id": str(r["id"]),
+            "query_text": r["query_text"],
+            "description": r["description"],
+            "summary_format": r["summary_format"],
+        }
+        for r in rows
+    ]
+
+
 @app.get("/api/explore/census-demographics", response_model=ExploreResponse)
 async def get_census_demographics(
     request: Request,

--- a/tests/test_explore_api.py
+++ b/tests/test_explore_api.py
@@ -836,3 +836,32 @@ class TestStaffUploadsExplore:
             "/api/explore/staff-uploads?upload_id=00000000-0000-0000-0000-00000000dead"
         )
         assert resp.status_code == 404
+
+
+class TestExampleQueryTemplates:
+    @pytest.mark.asyncio
+    async def test_lists_approved_example_queries(self, user_client, override_db):
+        mock_db = override_db
+        fetch_result = MagicMock()
+        fetch_result.mappings.return_value.all.return_value = [
+            {
+                "id": "00000000-0000-0000-0000-00000000b001",
+                "query_text": "What does the data show about eviction risk?",
+                "description": "Housing justice framing",
+                "summary_format": "detailed",
+            },
+        ]
+        mock_db.execute = AsyncMock(return_value=fetch_result)
+
+        resp = await user_client.get("/api/explore/example-query-templates")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["query_text"].startswith("What does")
+        assert data[0]["description"] == "Housing justice framing"
+        assert data[0]["summary_format"] == "detailed"
+
+    @pytest.mark.asyncio
+    async def test_example_query_templates_require_auth(self, unauth_client):
+        resp = await unauth_client.get("/api/explore/example-query-templates")
+        assert resp.status_code == 401

--- a/tests/test_training/test_generate_pairs.py
+++ b/tests/test_training/test_generate_pairs.py
@@ -14,6 +14,7 @@ from scripts.training.generate_training_pairs import (
     _validate_json,
     format_as_chatml,
     generate_query_parser_questions,
+    merge_staff_example_queries_for_parser,
     write_pairs_jsonl,
 )
 
@@ -218,6 +219,44 @@ class TestGenerateQueryParserQuestions:
         rows = self._sample_seed_rows()
         result = generate_query_parser_questions(rows, count=0)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# merge_staff_example_queries_for_parser
+# ---------------------------------------------------------------------------
+
+
+class TestMergeStaffExampleQueriesForParser:
+    def test_staff_prefixed_with_community_style(self):
+        seeds = [
+            {"state_name": "Mississippi", "metric": "poverty_rate", "race": "black", "year": 2020},
+        ]
+        staff = [{"query_text": "  Custom organizer question?  ", "description": "Housing"}]
+        out = merge_staff_example_queries_for_parser(seeds, 4, staff)
+        assert len(out) == 4
+        assert out[0]["question"] == "Custom organizer question?"
+        assert out[0]["style"] == "community"
+        assert out[0]["seed_data"]["source"] == "staff_example_query"
+
+    def test_truncates_staff_when_total_smaller(self):
+        seeds = [{"state_name": "MS", "metric": "poverty_rate", "race": "black", "year": 2020}]
+        staff = [
+            {"query_text": "One", "description": ""},
+            {"query_text": "Two", "description": ""},
+        ]
+        out = merge_staff_example_queries_for_parser(seeds, 1, staff)
+        assert len(out) == 1
+        assert out[0]["question"] == "One"
+
+    def test_skips_blank_staff_queries(self):
+        seeds = [{"state_name": "MS", "metric": "poverty_rate", "race": "black", "year": 2020}]
+        staff = [
+            {"query_text": "   ", "description": ""},
+            {"query_text": "Valid", "description": ""},
+        ]
+        out = merge_staff_example_queries_for_parser(seeds, 2, staff)
+        assert len(out) == 2
+        assert out[0]["question"] == "Valid"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_training/test_generate_pairs.py
+++ b/tests/test_training/test_generate_pairs.py
@@ -456,6 +456,28 @@ class TestCLIFlags:
         )
         assert result.returncode == 0, result.stderr
 
+    def test_include_approved_defaults_false(self):
+        result = subprocess.run(
+            [sys.executable, "-c",
+             "from scripts.training.generate_training_pairs import _build_arg_parser; "
+             "p = _build_arg_parser(); "
+             "args = p.parse_args(['--task', 'query_parser']); "
+             "assert args.include_approved_example_queries is False"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_include_approved_flag_true(self):
+        result = subprocess.run(
+            [sys.executable, "-c",
+             "from scripts.training.generate_training_pairs import _build_arg_parser; "
+             "p = _build_arg_parser(); "
+             "args = p.parse_args(['--task', 'query_parser', '--include-approved-example-queries']); "
+             "assert args.include_approved_example_queries is True"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
     def test_new_v3_task_choices_accepted(self):
         for task in ["evaluator_v3", "query_parser_v3"]:
             result = subprocess.run(

--- a/tests/test_training/test_templates.py
+++ b/tests/test_training/test_templates.py
@@ -7,9 +7,28 @@ from scripts.training.templates import (
     render_cdc_passage,
     render_census_passage,
     render_epa_passage,
+    render_example_query_passage,
     render_fbi_passage,
     render_police_violence_passage,
 )
+
+
+class TestRenderExampleQueryPassage:
+    def test_empty_without_query_text(self):
+        assert render_example_query_passage({}) == ""
+        assert render_example_query_passage({"query_text": "  "}) == ""
+
+    def test_query_only(self):
+        p = render_example_query_passage({"query_text": "How does redlining affect asthma?"})
+        assert "How does redlining affect asthma?" in p
+        assert "Contributor framing" not in p
+
+    def test_includes_description(self):
+        p = render_example_query_passage(
+            {"query_text": "Q?", "description": "Organizer-submitted housing prompt."},
+        )
+        assert "Q?" in p
+        assert "Organizer-submitted housing prompt." in p
 
 # ---------------------------------------------------------------------------
 # Census

--- a/ui-nextjs/components/explore/ExploreQueryBar.tsx
+++ b/ui-nextjs/components/explore/ExploreQueryBar.tsx
@@ -43,7 +43,8 @@ export default function ExploreQueryBar({
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+
+    async function loadTemplates() {
       try {
         const resp = await fetch(`${API_BASE}/api/explore/example-query-templates`, {
           headers: getHeaders(),
@@ -54,7 +55,9 @@ export default function ExploreQueryBar({
       } catch {
         /* ignore — templates are optional */
       }
-    })();
+    }
+
+    void loadTemplates();
     return () => {
       cancelled = true;
     };

--- a/ui-nextjs/components/explore/ExploreQueryBar.tsx
+++ b/ui-nextjs/components/explore/ExploreQueryBar.tsx
@@ -34,7 +34,7 @@ export default function ExploreQueryBar({
   year,
   accent,
 }: ExploreQueryBarProps) {
-  const { getHeaders } = useAuthHeaders();
+  const { session, getHeaders } = useAuthHeaders();
   const [question, setQuestion] = useState('');
   const [loading, setLoading] = useState(false);
   const [answer, setAnswer] = useState<string | null>(null);
@@ -42,6 +42,10 @@ export default function ExploreQueryBar({
   const [templates, setTemplates] = useState<ExampleQueryTemplate[]>([]);
 
   useEffect(() => {
+    if (!session?.access_token) {
+      return;
+    }
+
     let cancelled = false;
 
     async function loadTemplates() {
@@ -61,9 +65,7 @@ export default function ExploreQueryBar({
     return () => {
       cancelled = true;
     };
-    // Intentionally once on mount: getHeaders identity can change each render and would refetch.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [session?.access_token, getHeaders]);
 
   const handleSubmit = useCallback(
     async (e?: FormEvent) => {

--- a/ui-nextjs/components/explore/ExploreQueryBar.tsx
+++ b/ui-nextjs/components/explore/ExploreQueryBar.tsx
@@ -61,7 +61,9 @@ export default function ExploreQueryBar({
     return () => {
       cancelled = true;
     };
-  }, [getHeaders]);
+    // Intentionally once on mount: getHeaders identity can change each render and would refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSubmit = useCallback(
     async (e?: FormEvent) => {

--- a/ui-nextjs/components/explore/ExploreQueryBar.tsx
+++ b/ui-nextjs/components/explore/ExploreQueryBar.tsx
@@ -1,8 +1,15 @@
 'use client';
 
-import { useState, useCallback, FormEvent, KeyboardEvent } from 'react';
+import { useState, useCallback, useEffect, FormEvent, KeyboardEvent } from 'react';
 import { API_BASE } from '@/lib/api';
 import { useAuthHeaders } from '@/hooks/useAuthHeaders';
+
+interface ExampleQueryTemplate {
+  id: string;
+  query_text: string;
+  description: string;
+  summary_format: string;
+}
 
 interface ExploreQueryBarProps {
   source: string;
@@ -32,6 +39,26 @@ export default function ExploreQueryBar({
   const [loading, setLoading] = useState(false);
   const [answer, setAnswer] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [templates, setTemplates] = useState<ExampleQueryTemplate[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch(`${API_BASE}/api/explore/example-query-templates`, {
+          headers: getHeaders(),
+        });
+        if (!resp.ok) return;
+        const data = (await resp.json()) as ExampleQueryTemplate[];
+        if (!cancelled && Array.isArray(data)) setTemplates(data);
+      } catch {
+        /* ignore — templates are optional */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getHeaders]);
 
   const handleSubmit = useCallback(
     async (e?: FormEvent) => {
@@ -86,6 +113,28 @@ export default function ExploreQueryBar({
 
   return (
     <div className="mt-6 mb-4">
+      {templates.length > 0 && (
+        <div className="mb-3">
+          <p className="text-xs text-gray-500 mb-2">Try a contributor example</p>
+          <div className="flex flex-wrap gap-2">
+            {templates.map((t) => {
+              const label =
+                t.query_text.length > 72 ? `${t.query_text.slice(0, 70)}…` : t.query_text;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  title={t.description ? `${t.query_text}\n\n${t.description}` : t.query_text}
+                  onClick={() => setQuestion(t.query_text)}
+                  className="text-left text-xs px-2.5 py-1.5 rounded-md border border-[#404040] bg-[#141414] text-gray-200 hover:border-gray-500 transition-colors max-w-full"
+                >
+                  <span className="line-clamp-2">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
       <form onSubmit={handleSubmit} className="flex gap-2">
         <input
           type="text"


### PR DESCRIPTION
## Summary

This change completes the post-approval path for staff-submitted example queries, consistent with approved documents and approved data-source uploads. Queries that reach `approved` status are pulled from `example_queries` (via `uploads`) into the training pipeline and listed in Explore as reusable NL templates.

## What changed

- **Corpus extraction** adds an `approved_example_queries` source so pretraining JSONL can include real question phrasing. Extraction skips that source cleanly when the upload tables are not present.
- **Query-parser distillation** prepends approved questions (teacher uses community style), then fills the remainder from synthetic seeds. **Query-parser v2** injects approved text into the intersectional batch when the queue is non-empty.
- **API** exposes `GET /api/explore/example-query-templates` for authenticated clients (same pattern as other Explore routes).
- **Explore UI** loads those templates and shows short chips above the conversational query bar; choosing a chip fills the input.

## Testing

Targeted pytest runs covered the new merge helpers, template rendering, API handler wiring, and related Explore and training tests (including `test_extract_corpus`).

Closes #192

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Try a contributor example" section in Explore with approved example query suggestions.
  * API endpoint to list approved example query templates.
  * Training pipeline opt-in flag to include approved staff example queries with deterministic staging/resume behavior.
  * New renderer to format example-query passages for training/UI.

* **Bug Fixes**
  * Missing or unavailable example-query data now logs a warning and returns empty results instead of failing.

* **Tests**
  * Added tests for the API, rendering, training pair merging/injection, CLI flag, and UI integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->