### PR TITLE
feat(explore): related documents panel (#154)

### DIFF
--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -20,7 +20,7 @@ from uuid import UUID, uuid4
 
 from fastapi import Body, Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy import String, desc, func, select, text
+from sqlalchemy import String, bindparam, desc, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
@@ -52,11 +52,11 @@ from d4bl.app.schemas import (
     PipelinePath,
     PipelineStep,
     PolicyBillItem,
-    RelatedDocumentItem,
-    RelatedDocumentsResponse,
     QueryRequest,
     QueryResponse,
     QuerySourceItem,
+    RelatedDocumentItem,
+    RelatedDocumentsResponse,
     ResearchRequest,
     ResearchResponse,
     StateSummaryItem,
@@ -441,11 +441,16 @@ _RELATED_DOC_CONTENT_TYPES: frozenset[str] = frozenset(
 
 
 def _parse_related_doc_types_param(raw: str | None) -> list[str]:
-    """Return sorted content_type values for the documents query (allowlist-only)."""
+    """Return sorted content_type values for the documents query (allowlist-only).
+
+    When *raw* is omitted or blank, all allowed types are used. When *raw* is
+    non-blank but contains no allowed tokens, returns an empty list (caller
+    should respond with 422).
+    """
     if not raw or not raw.strip():
         return sorted(_RELATED_DOC_CONTENT_TYPES)
     picked = [t.strip() for t in raw.split(",") if t.strip() in _RELATED_DOC_CONTENT_TYPES]
-    return sorted(set(picked)) if picked else sorted(_RELATED_DOC_CONTENT_TYPES)
+    return sorted(set(picked))
 
 
 def _normalize_metric_for_document_search(metric: str | None) -> tuple[bool, str, str]:
@@ -464,6 +469,7 @@ def _normalize_metric_for_document_search(metric: str | None) -> tuple[bool, str
 async def _fetch_related_documents(
     db: AsyncSession,
     *,
+    viewer_user_id: UUID,
     state_fips: str,
     metric: str | None,
     content_types: list[str],
@@ -472,19 +478,21 @@ async def _fetch_related_documents(
     limit: int,
 ) -> RelatedDocumentsResponse:
     """Load documents linked to a state, optionally narrowed by metric text."""
+    if not content_types:
+        return RelatedDocumentsResponse(documents=[], total=0)
+
     abbrev = FIPS_TO_ABBREV.get(state_fips)
     if not abbrev:
         raise HTTPException(status_code=422, detail="Invalid state_fips")
     state_name = FIPS_TO_NAME.get(state_fips, "")
     has_metric, metric_slug, metric_human = _normalize_metric_for_document_search(metric)
 
-    type_sql = ",".join(f"'{t}'" for t in content_types)
     sort_col = {"created_at": "created_at", "title": "title", "content_type": "content_type"}.get(
         sort,
         "created_at",
     )
     order_sql = "ASC" if order.lower() == "asc" else "DESC"
-    nulls = "NULLS LAST" if sort_col == "title" else ""
+    nulls = "NULLS LAST" if sort_col in ("created_at", "title") else ""
 
     metric_clause = "TRUE"
     params: dict[str, object] = {
@@ -492,6 +500,8 @@ async def _fetch_related_documents(
         "abbrev_lc": abbrev.lower(),
         "state_name": state_name.lower(),
         "limit": limit,
+        "viewer_id": str(viewer_user_id),
+        "ct_types": tuple(content_types),
     }
     if has_metric:
         metric_clause = """(
@@ -503,8 +513,9 @@ async def _fetch_related_documents(
         params["metric_slug"] = metric_slug
         params["metric_human"] = metric_human
 
-    stmt = text(
-        f"""
+    stmt = (
+        text(
+            f"""
         SELECT * FROM (
             SELECT
                 d.id::text AS id,
@@ -524,7 +535,7 @@ async def _fetch_related_documents(
                 ORDER BY chunk_index ASC
                 LIMIT 1
             ) c ON true
-            WHERE d.content_type IN ({type_sql})
+            WHERE d.content_type IN :ct_types
               AND (
                 (d.content_type = 'policy_bill' AND COALESCE(d.metadata->>'state', '') = :abbrev)
                 OR (strpos(lower(COALESCE(d.title, '')), :state_name) > 0)
@@ -532,10 +543,19 @@ async def _fetch_related_documents(
                 OR (strpos(lower(COALESCE(c.content, '')), :state_name) > 0)
               )
               AND ({metric_clause})
+              AND (
+                d.job_id IS NULL
+                OR EXISTS (
+                    SELECT 1 FROM research_jobs rj
+                    WHERE rj.job_id = d.job_id
+                      AND rj.user_id = CAST(:viewer_id AS uuid)
+                )
+              )
         ) sub
         ORDER BY sub.{sort_col} {order_sql} {nulls}
         LIMIT :limit
         """
+        ).bindparams(bindparam("ct_types", expanding=True))
     )
 
     result = await db.execute(stmt, params)
@@ -2193,7 +2213,7 @@ async def list_related_documents(
     sort: str = "created_at",
     order: str = "desc",
     limit: int = 50,
-    _user: CurrentUser = Depends(get_current_user),
+    user: CurrentUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Related documents for Explore: policy bills, research reports, scraped pages.
@@ -2201,6 +2221,7 @@ async def list_related_documents(
     Requires ``state_fips``. Optional ``metric`` keeps rows whose title, JSON metadata,
     or first text chunk matches the metric slug or a humanized phrase (underscores to spaces).
     ``types`` is a comma-separated subset of policy_bill,research_report,scraped,scraped_web.
+    Job-linked rows are limited to research jobs owned by the authenticated user.
     """
     if sort not in {"created_at", "title", "content_type"}:
         raise HTTPException(status_code=422, detail="Invalid sort field")
@@ -2209,9 +2230,12 @@ async def list_related_documents(
         raise HTTPException(status_code=422, detail="Invalid order")
     lim = max(1, min(limit, 200))
     ct = _parse_related_doc_types_param(types)
+    if types and types.strip() and not ct:
+        raise HTTPException(status_code=422, detail="Invalid document types")
     try:
         return await _fetch_related_documents(
             db,
+            viewer_user_id=user.id,
             state_fips=state_fips,
             metric=metric,
             content_types=ct,

--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -498,7 +498,6 @@ async def _fetch_related_documents(
     metric_clause = "TRUE"
     params: dict[str, object] = {
         "abbrev": abbrev,
-        "abbrev_lc": abbrev.lower(),
         "state_name": state_name.lower(),
         "limit": limit,
         "viewer_id": str(viewer_user_id),
@@ -540,7 +539,6 @@ async def _fetch_related_documents(
               AND (
                 (d.content_type = 'policy_bill' AND COALESCE(d.metadata->>'state', '') = :abbrev)
                 OR (strpos(lower(COALESCE(d.title, '')), :state_name) > 0)
-                OR (strpos(lower(COALESCE(d.source_url, '')), :abbrev_lc) > 0)
                 OR (strpos(lower(COALESCE(c.content, '')), :state_name) > 0)
               )
               AND ({metric_clause})

--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -486,6 +486,7 @@ async def _fetch_related_documents(
         raise HTTPException(status_code=422, detail="Invalid state_fips")
     state_name = FIPS_TO_NAME.get(state_fips, "")
     has_metric, metric_slug, metric_human = _normalize_metric_for_document_search(metric)
+    # Metric filtering uses strpos / metadata::text (no GIN yet). Revisit if this becomes hot.
 
     sort_col = {"created_at": "created_at", "title": "title", "content_type": "content_type"}.get(
         sort,

--- a/src/d4bl/app/api.py
+++ b/src/d4bl/app/api.py
@@ -52,6 +52,8 @@ from d4bl.app.schemas import (
     PipelinePath,
     PipelineStep,
     PolicyBillItem,
+    RelatedDocumentItem,
+    RelatedDocumentsResponse,
     QueryRequest,
     QueryResponse,
     QuerySourceItem,
@@ -431,6 +433,135 @@ async def fetch_research_job(db: AsyncSession, job_uuid: UUID) -> ResearchJob:
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
+
+
+_RELATED_DOC_CONTENT_TYPES: frozenset[str] = frozenset(
+    {"policy_bill", "research_report", "scraped", "scraped_web"}
+)
+
+
+def _parse_related_doc_types_param(raw: str | None) -> list[str]:
+    """Return sorted content_type values for the documents query (allowlist-only)."""
+    if not raw or not raw.strip():
+        return sorted(_RELATED_DOC_CONTENT_TYPES)
+    picked = [t.strip() for t in raw.split(",") if t.strip() in _RELATED_DOC_CONTENT_TYPES]
+    return sorted(set(picked)) if picked else sorted(_RELATED_DOC_CONTENT_TYPES)
+
+
+def _normalize_metric_for_document_search(metric: str | None) -> tuple[bool, str, str]:
+    """Return (has_metric, slug_lower, human_phrase_lower) for safe substring matching."""
+    if not metric or not metric.strip():
+        return False, "", ""
+    slug = metric.strip().lower()[:120]
+    allowed = set("abcdefghijklmnopqrstuvwxyz0123456789_ -")
+    slug = "".join(ch for ch in slug if ch in allowed).strip()
+    if not slug:
+        return False, "", ""
+    human = slug.replace("_", " ")
+    return True, slug, human
+
+
+async def _fetch_related_documents(
+    db: AsyncSession,
+    *,
+    state_fips: str,
+    metric: str | None,
+    content_types: list[str],
+    sort: str,
+    order: str,
+    limit: int,
+) -> RelatedDocumentsResponse:
+    """Load documents linked to a state, optionally narrowed by metric text."""
+    abbrev = FIPS_TO_ABBREV.get(state_fips)
+    if not abbrev:
+        raise HTTPException(status_code=422, detail="Invalid state_fips")
+    state_name = FIPS_TO_NAME.get(state_fips, "")
+    has_metric, metric_slug, metric_human = _normalize_metric_for_document_search(metric)
+
+    type_sql = ",".join(f"'{t}'" for t in content_types)
+    sort_col = {"created_at": "created_at", "title": "title", "content_type": "content_type"}.get(
+        sort,
+        "created_at",
+    )
+    order_sql = "ASC" if order.lower() == "asc" else "DESC"
+    nulls = "NULLS LAST" if sort_col == "title" else ""
+
+    metric_clause = "TRUE"
+    params: dict[str, object] = {
+        "abbrev": abbrev,
+        "abbrev_lc": abbrev.lower(),
+        "state_name": state_name.lower(),
+        "limit": limit,
+    }
+    if has_metric:
+        metric_clause = """(
+            strpos(lower(COALESCE(d.title, '')), :metric_slug) > 0
+            OR strpos(lower(COALESCE(d.metadata::text, '')), :metric_slug) > 0
+            OR strpos(lower(COALESCE(c.content, '')), :metric_slug) > 0
+            OR strpos(lower(COALESCE(c.content, '')), :metric_human) > 0
+        )"""
+        params["metric_slug"] = metric_slug
+        params["metric_human"] = metric_human
+
+    stmt = text(
+        f"""
+        SELECT * FROM (
+            SELECT
+                d.id::text AS id,
+                d.title,
+                d.source_url,
+                d.content_type,
+                d.source_key,
+                CASE WHEN d.job_id IS NULL THEN NULL ELSE d.job_id::text END AS job_id,
+                d.created_at,
+                LEFT(COALESCE(c.content, ''), 320) AS snippet,
+                d.metadata AS metadata,
+                COUNT(*) OVER() AS _total
+            FROM documents d
+            LEFT JOIN LATERAL (
+                SELECT content FROM document_chunks
+                WHERE document_id = d.id
+                ORDER BY chunk_index ASC
+                LIMIT 1
+            ) c ON true
+            WHERE d.content_type IN ({type_sql})
+              AND (
+                (d.content_type = 'policy_bill' AND COALESCE(d.metadata->>'state', '') = :abbrev)
+                OR (strpos(lower(COALESCE(d.title, '')), :state_name) > 0)
+                OR (strpos(lower(COALESCE(d.source_url, '')), :abbrev_lc) > 0)
+                OR (strpos(lower(COALESCE(c.content, '')), :state_name) > 0)
+              )
+              AND ({metric_clause})
+        ) sub
+        ORDER BY sub.{sort_col} {order_sql} {nulls}
+        LIMIT :limit
+        """
+    )
+
+    result = await db.execute(stmt, params)
+    rows = result.mappings().all()
+    total = int(rows[0]["_total"]) if rows else 0
+    items: list[RelatedDocumentItem] = []
+    for r in rows:
+        meta = r.get("metadata")
+        if meta is not None and not isinstance(meta, dict):
+            meta = None
+        ca = r.get("created_at")
+        created = ca.isoformat() if hasattr(ca, "isoformat") else (str(ca) if ca else None)
+        items.append(
+            RelatedDocumentItem(
+                id=r["id"],
+                title=r.get("title"),
+                source_url=r.get("source_url"),
+                content_type=r["content_type"],
+                source_key=r.get("source_key"),
+                job_id=r.get("job_id"),
+                created_at=created,
+                snippet=r.get("snippet") or None,
+                metadata=meta,
+            )
+        )
+    return RelatedDocumentsResponse(documents=items, total=total)
 
 
 _background_tasks: set = set()
@@ -2052,6 +2183,47 @@ async def get_policies(
     except Exception as e:
         logger.error("Error fetching policies: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Error fetching policies") from e
+
+
+@app.get("/api/documents", response_model=RelatedDocumentsResponse)
+async def list_related_documents(
+    state_fips: str,
+    metric: str | None = None,
+    types: str | None = None,
+    sort: str = "created_at",
+    order: str = "desc",
+    limit: int = 50,
+    _user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Related documents for Explore: policy bills, research reports, scraped pages.
+
+    Requires ``state_fips``. Optional ``metric`` keeps rows whose title, JSON metadata,
+    or first text chunk matches the metric slug or a humanized phrase (underscores to spaces).
+    ``types`` is a comma-separated subset of policy_bill,research_report,scraped,scraped_web.
+    """
+    if sort not in {"created_at", "title", "content_type"}:
+        raise HTTPException(status_code=422, detail="Invalid sort field")
+    o = order.lower()
+    if o not in {"asc", "desc"}:
+        raise HTTPException(status_code=422, detail="Invalid order")
+    lim = max(1, min(limit, 200))
+    ct = _parse_related_doc_types_param(types)
+    try:
+        return await _fetch_related_documents(
+            db,
+            state_fips=state_fips,
+            metric=metric,
+            content_types=ct,
+            sort=sort,
+            order=o,
+            limit=lim,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error listing related documents: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Error listing documents") from e
 
 
 @app.get("/api/explore/states", response_model=list[StateSummaryItem])

--- a/src/d4bl/app/schemas.py
+++ b/src/d4bl/app/schemas.py
@@ -170,6 +170,27 @@ class PolicyBillItem(BaseModel):
     url: str | None = None
 
 
+class RelatedDocumentItem(BaseModel):
+    """Unified document row for Explore related-documents panel."""
+
+    id: str
+    title: str | None = None
+    source_url: str | None = None
+    content_type: str
+    source_key: str | None = None
+    job_id: str | None = None
+    created_at: str | None = None
+    snippet: str | None = None
+    metadata: dict[str, object] | None = None
+
+
+class RelatedDocumentsResponse(BaseModel):
+    """Paginated related documents for a state (and optional metric) context."""
+
+    documents: list[RelatedDocumentItem]
+    total: int
+
+
 class StateSummaryItem(BaseModel):
     """Per-state metadata: available metrics, bill count, and latest year."""
 

--- a/tests/test_related_documents_params.py
+++ b/tests/test_related_documents_params.py
@@ -1,11 +1,18 @@
 """Unit tests for related-documents API query parsing helpers."""
 
-from d4bl.app.api import _normalize_metric_for_document_search, _parse_related_doc_types_param
+from d4bl.app.api import (
+    _RELATED_DOC_CONTENT_TYPES,
+    _normalize_metric_for_document_search,
+    _parse_related_doc_types_param,
+)
+
+_EXPECTED_ALL_TYPES = sorted(_RELATED_DOC_CONTENT_TYPES)
 
 
 def test_parse_types_default_all():
-    assert "policy_bill" in _parse_related_doc_types_param(None)
-    assert "research_report" in _parse_related_doc_types_param("")
+    assert _parse_related_doc_types_param(None) == _EXPECTED_ALL_TYPES
+    assert _parse_related_doc_types_param("") == _EXPECTED_ALL_TYPES
+    assert _parse_related_doc_types_param("   ") == _EXPECTED_ALL_TYPES
 
 
 def test_parse_types_filters_unknown():

--- a/tests/test_related_documents_params.py
+++ b/tests/test_related_documents_params.py
@@ -1,0 +1,35 @@
+"""Unit tests for related-documents API query parsing helpers."""
+
+from d4bl.app.api import _normalize_metric_for_document_search, _parse_related_doc_types_param
+
+
+def test_parse_types_default_all():
+    assert "policy_bill" in _parse_related_doc_types_param(None)
+    assert "research_report" in _parse_related_doc_types_param("")
+
+
+def test_parse_types_filters_unknown():
+    assert _parse_related_doc_types_param("policy_bill,nope") == ["policy_bill"]
+
+
+def test_parse_types_multiple():
+    got = _parse_related_doc_types_param("scraped_web, policy_bill ")
+    assert got == ["policy_bill", "scraped_web"]
+
+
+def test_normalize_metric_empty():
+    assert _normalize_metric_for_document_search(None) == (False, "", "")
+    assert _normalize_metric_for_document_search("   ") == (False, "", "")
+
+
+def test_normalize_metric_slug_and_human():
+    has, slug, human = _normalize_metric_for_document_search("Median_Household_Income")
+    assert has is True
+    assert slug == "median_household_income"
+    assert human == "median household income"
+
+
+def test_normalize_metric_strips_unsafe_chars():
+    has, slug, _ = _normalize_metric_for_document_search("test%drop")
+    assert has is True
+    assert slug == "testdrop"

--- a/tests/test_related_documents_params.py
+++ b/tests/test_related_documents_params.py
@@ -12,6 +12,10 @@ def test_parse_types_filters_unknown():
     assert _parse_related_doc_types_param("policy_bill,nope") == ["policy_bill"]
 
 
+def test_parse_types_all_invalid_returns_empty():
+    assert _parse_related_doc_types_param("nope,bad") == []
+
+
 def test_parse_types_multiple():
     got = _parse_related_doc_types_param("scraped_web, policy_bill ")
     assert got == ["policy_bill", "scraped_web"]

--- a/ui-nextjs/app/explore/page.tsx
+++ b/ui-nextjs/app/explore/page.tsx
@@ -13,6 +13,7 @@ import PolicyExploreView from '@/components/explore/PolicyExploreView';
 import StateAnnotation from '@/components/explore/StateAnnotation';
 import ExplainPanel from '@/components/explore/ExplainPanel';
 import ExploreQueryBar from '@/components/explore/ExploreQueryBar';
+import RelatedDocuments from '@/components/explore/RelatedDocuments';
 import MapLegend from '@/components/explore/MapLegend';
 import DataTable from '@/components/explore/DataTable';
 import { IndicatorRow, PolicyBill, ExploreResponse } from '@/lib/types';
@@ -522,6 +523,16 @@ export default function ExplorePage() {
               />
             )}
           </div>
+        )}
+
+        {filters.selectedState && exploreData && exploreData.rows.length > 0 && (
+          <RelatedDocuments
+            stateFips={filters.selectedState}
+            metric={resolvedMetric || null}
+            accent={activeSource.accent}
+            getHeaders={getHeaders}
+            sessionReady={Boolean(session?.access_token)}
+          />
         )}
 
         {/* Conversational Query Bar */}

--- a/ui-nextjs/components/explore/RelatedDocuments.tsx
+++ b/ui-nextjs/components/explore/RelatedDocuments.tsx
@@ -146,6 +146,8 @@ export default function RelatedDocuments({
     }
 
     if (collapsed) {
+      setRows([]);
+      setTotal(0);
       setLoading(false);
       return;
     }

--- a/ui-nextjs/components/explore/RelatedDocuments.tsx
+++ b/ui-nextjs/components/explore/RelatedDocuments.tsx
@@ -138,12 +138,15 @@ export default function RelatedDocuments({
 
   useEffect(() => {
     if (!sessionReady || !stateFips) {
+      setLoading(false);
+      setError(null);
       setRows([]);
       setTotal(0);
       return;
     }
 
     if (collapsed) {
+      setLoading(false);
       return;
     }
 
@@ -175,7 +178,7 @@ export default function RelatedDocuments({
         setRows([]);
         setTotal(0);
       } finally {
-        if (!controller.signal.aborted) setLoading(false);
+        setLoading(false);
       }
     })();
 

--- a/ui-nextjs/components/explore/RelatedDocuments.tsx
+++ b/ui-nextjs/components/explore/RelatedDocuments.tsx
@@ -71,13 +71,29 @@ function HeaderCell({ col, label, align = 'left', sortKey, sortDir, accent, onSo
     date: 'created_at',
   };
   const sk = map[col];
+  const ariaSort =
+    sortKey === sk ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none';
+  const sortLabel =
+    sortKey === sk
+      ? `${label}, sorted ${sortDir === 'asc' ? 'ascending' : 'descending'}`
+      : `${label}, activate to sort`;
+
   return (
     <th
-      className={`px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[#999] cursor-pointer select-none whitespace-nowrap hover:text-[#ccc] transition-colors ${align === 'right' ? 'text-right' : 'text-left'}`}
-      onClick={() => onSort(col)}
+      aria-sort={ariaSort}
+      className={`px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[#999] whitespace-nowrap ${align === 'right' ? 'text-right' : 'text-left'}`}
     >
-      {label}
-      <SortIcon active={sortKey === sk} dir={sortDir} accent={accent} />
+      <button
+        type="button"
+        onClick={() => onSort(col)}
+        className={`inline-flex items-center cursor-pointer select-none hover:text-[#ccc] transition-colors ${
+          align === 'right' ? 'justify-end w-full text-right' : 'text-left'
+        }`}
+        aria-label={sortLabel}
+      >
+        {label}
+        <SortIcon active={sortKey === sk} dir={sortDir} accent={accent} />
+      </button>
     </th>
   );
 }
@@ -127,6 +143,10 @@ export default function RelatedDocuments({
       return;
     }
 
+    if (collapsed) {
+      return;
+    }
+
     const controller = new AbortController();
     (async () => {
       setLoading(true);
@@ -160,7 +180,7 @@ export default function RelatedDocuments({
     })();
 
     return () => controller.abort();
-  }, [sessionReady, stateFips, metric, sortKey, sortDir, typesParam, getHeaders]);
+  }, [sessionReady, stateFips, metric, sortKey, sortDir, typesParam, getHeaders, collapsed]);
 
   function handleHeaderSort(col: ColKey) {
     const map: Record<ColKey, SortKey> = {
@@ -195,7 +215,11 @@ export default function RelatedDocuments({
         <h2 className="text-sm font-semibold text-[#e5e5e5]">Related documents</h2>
         <span className="text-xs text-[#666]">
           {metricLabel}
-          {total > 0 ? ` · ${total} match${total === 1 ? '' : 'es'}` : ''}
+          {total > 0
+            ? rows.length < total
+              ? ` · Showing ${rows.length} of ${total} match${total === 1 ? '' : 'es'}`
+              : ` · ${total} match${total === 1 ? '' : 'es'}`
+            : ''}
         </span>
       </div>
 
@@ -281,6 +305,12 @@ export default function RelatedDocuments({
                   {rows.map((doc) => {
                     const href =
                       doc.source_url && /^https?:\/\//i.test(doc.source_url) ? doc.source_url : null;
+                    const noUrlTitle =
+                      doc.source_key && !href
+                        ? 'No public URL yet for this storage-backed document.'
+                        : doc.job_id && !href
+                          ? 'No direct link; open Research and find this job in history.'
+                          : undefined;
                     return (
                       <tr
                         key={doc.id}
@@ -312,7 +342,7 @@ export default function RelatedDocuments({
                               Open ↗
                             </a>
                           ) : (
-                            <span className="text-xs text-[#555]">
+                            <span className="text-xs text-[#555]" title={noUrlTitle}>
                               {doc.content_type === 'research_report' ? 'Report' : '—'}
                             </span>
                           )}

--- a/ui-nextjs/components/explore/RelatedDocuments.tsx
+++ b/ui-nextjs/components/explore/RelatedDocuments.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RelatedDocument, RelatedDocumentsResponse } from '@/lib/types';
 import { API_BASE } from '@/lib/api';
 import { humanizeMetric } from '@/lib/explore-config';
@@ -124,6 +124,12 @@ export default function RelatedDocuments({
 
   const typesParam = useMemo(() => categoryToTypesParam(category), [category]);
 
+  // Stable ref for getHeaders to prevent unnecessary refetches
+  const getHeadersRef = useRef(getHeaders);
+  useEffect(() => {
+    getHeadersRef.current = getHeaders;
+  }, [getHeaders]);
+
   const toggleCollapse = useCallback(() => {
     setCollapsed((prev) => {
       const next = !prev;
@@ -168,7 +174,7 @@ export default function RelatedDocuments({
 
         const res = await fetch(`${API_BASE}/api/documents?${params}`, {
           signal: controller.signal,
-          headers: getHeaders(),
+          headers: getHeadersRef.current(),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = (await res.json()) as RelatedDocumentsResponse;
@@ -185,7 +191,7 @@ export default function RelatedDocuments({
     })();
 
     return () => controller.abort();
-  }, [sessionReady, stateFips, metric, sortKey, sortDir, typesParam, getHeaders, collapsed]);
+  }, [sessionReady, stateFips, metric, sortKey, sortDir, typesParam, collapsed]);
 
   function handleHeaderSort(col: ColKey) {
     const map: Record<ColKey, SortKey> = {

--- a/ui-nextjs/components/explore/RelatedDocuments.tsx
+++ b/ui-nextjs/components/explore/RelatedDocuments.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RelatedDocument, RelatedDocumentsResponse } from '@/lib/types';
+import { API_BASE } from '@/lib/api';
+import { humanizeMetric } from '@/lib/explore-config';
+
+const COLLAPSE_KEY = 'd4bl-explore-related-docs-collapsed';
+
+function loadCollapsePreference(defaultValue: boolean): boolean {
+  if (typeof window === 'undefined') return defaultValue;
+  try {
+    const stored = window.localStorage.getItem(COLLAPSE_KEY);
+    return stored !== null ? stored === 'true' : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+type CategoryFilter = 'all' | 'policy' | 'research' | 'web';
+
+type SortKey = 'created_at' | 'title' | 'content_type';
+type SortDir = 'asc' | 'desc';
+
+function categoryToTypesParam(cat: CategoryFilter): string | null {
+  if (cat === 'all') return null;
+  if (cat === 'policy') return 'policy_bill';
+  if (cat === 'research') return 'research_report';
+  return 'scraped,scraped_web';
+}
+
+function docCategoryLabel(ct: string): string {
+  if (ct === 'policy_bill') return 'Policy';
+  if (ct === 'research_report') return 'Research';
+  if (ct === 'scraped' || ct === 'scraped_web') return 'Web';
+  return ct;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 10);
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function SortIcon({ active, dir, accent }: { active: boolean; dir: SortDir; accent: string }) {
+  if (!active) return <span className="ml-1 text-[#555]">↕</span>;
+  return (
+    <span className="ml-1" style={{ color: accent }}>
+      {dir === 'asc' ? '↑' : '↓'}
+    </span>
+  );
+}
+
+type ColKey = 'kind' | 'title' | 'date';
+
+interface HeaderCellProps {
+  col: ColKey;
+  label: string;
+  align?: 'left' | 'right';
+  sortKey: SortKey;
+  sortDir: SortDir;
+  accent: string;
+  onSort: (col: ColKey) => void;
+}
+
+function HeaderCell({ col, label, align = 'left', sortKey, sortDir, accent, onSort }: HeaderCellProps) {
+  const map: Record<ColKey, SortKey> = {
+    kind: 'content_type',
+    title: 'title',
+    date: 'created_at',
+  };
+  const sk = map[col];
+  return (
+    <th
+      className={`px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[#999] cursor-pointer select-none whitespace-nowrap hover:text-[#ccc] transition-colors ${align === 'right' ? 'text-right' : 'text-left'}`}
+      onClick={() => onSort(col)}
+    >
+      {label}
+      <SortIcon active={sortKey === sk} dir={sortDir} accent={accent} />
+    </th>
+  );
+}
+
+export interface RelatedDocumentsProps {
+  stateFips: string | null;
+  metric: string | null;
+  accent: string;
+  getHeaders: () => Record<string, string>;
+  sessionReady: boolean;
+}
+
+export default function RelatedDocuments({
+  stateFips,
+  metric,
+  accent,
+  getHeaders,
+  sessionReady,
+}: RelatedDocumentsProps) {
+  const [collapsed, setCollapsed] = useState(() => loadCollapsePreference(true));
+  const [category, setCategory] = useState<CategoryFilter>('all');
+  const [sortKey, setSortKey] = useState<SortKey>('created_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [rows, setRows] = useState<RelatedDocument[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const typesParam = useMemo(() => categoryToTypesParam(category), [category]);
+
+  const toggleCollapse = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(COLLAPSE_KEY, String(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!sessionReady || !stateFips) {
+      setRows([]);
+      setTotal(0);
+      return;
+    }
+
+    const controller = new AbortController();
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        params.set('state_fips', stateFips);
+        if (metric && metric.trim()) params.set('metric', metric.trim());
+        params.set('sort', sortKey);
+        params.set('order', sortDir);
+        params.set('limit', '100');
+        const tp = typesParam;
+        if (tp) params.set('types', tp);
+
+        const res = await fetch(`${API_BASE}/api/documents?${params}`, {
+          signal: controller.signal,
+          headers: getHeaders(),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as RelatedDocumentsResponse;
+        setRows(data.documents);
+        setTotal(data.total);
+      } catch (e: unknown) {
+        if (controller.signal.aborted) return;
+        setError(e instanceof Error ? e.message : 'Failed to load documents');
+        setRows([]);
+        setTotal(0);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [sessionReady, stateFips, metric, sortKey, sortDir, typesParam, getHeaders]);
+
+  function handleHeaderSort(col: ColKey) {
+    const map: Record<ColKey, SortKey> = {
+      kind: 'content_type',
+      title: 'title',
+      date: 'created_at',
+    };
+    const nextKey = map[col];
+    if (sortKey === nextKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(nextKey);
+      setSortDir(nextKey === 'title' || nextKey === 'content_type' ? 'asc' : 'desc');
+    }
+  }
+
+  if (!stateFips) return null;
+
+  const metricLabel = metric ? humanizeMetric(metric) : 'All metrics';
+
+  const chips: { id: CategoryFilter; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'policy', label: 'Policy' },
+    { id: 'research', label: 'Research' },
+    { id: 'web', label: 'News & web' },
+  ];
+
+  return (
+    <div className="mb-6 bg-[#111] border border-[#333] rounded-lg overflow-hidden">
+      <div className="px-4 py-3 border-b border-[#333] flex items-center gap-2 flex-wrap">
+        <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: accent }} />
+        <h2 className="text-sm font-semibold text-[#e5e5e5]">Related documents</h2>
+        <span className="text-xs text-[#666]">
+          {metricLabel}
+          {total > 0 ? ` · ${total} match${total === 1 ? '' : 'es'}` : ''}
+        </span>
+      </div>
+
+      <button
+        type="button"
+        onClick={toggleCollapse}
+        className="flex w-full items-center justify-between px-3 py-2 text-xs text-[#999] hover:text-white"
+      >
+        <span>
+          Bills, research, and scraped sources linked to this state
+          {loading && <span className="text-[#666] ml-2">Loading…</span>}
+        </span>
+        <span>{collapsed ? '▶' : '▼'}</span>
+      </button>
+
+      {!collapsed && (
+        <div className="px-3 pb-3 space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {chips.map((c) => (
+              <button
+                key={c.id}
+                type="button"
+                onClick={() => setCategory(c.id)}
+                className={`px-2.5 py-1 rounded text-xs border transition-colors ${
+                  category === c.id
+                    ? 'text-white border-[#555] bg-[#1f1f1f]'
+                    : 'text-[#888] border-[#333] hover:border-[#555] hover:text-[#ccc]'
+                }`}
+                style={category === c.id ? { borderColor: accent, boxShadow: `inset 0 0 0 1px ${accent}44` } : undefined}
+              >
+                {c.label}
+              </button>
+            ))}
+          </div>
+
+          {error && (
+            <div className="text-xs text-red-400 px-1">{error}</div>
+          )}
+
+          {!loading && !error && rows.length === 0 && (
+            <p className="text-xs text-[#777] px-1">
+              No related documents for this state and filter. Populate the document layer via
+              ingestion, research job crawls, or the one-time document migration when available.
+            </p>
+          )}
+
+          {rows.length > 0 && (
+            <div className="overflow-x-auto overflow-y-auto max-h-[360px] rounded border border-[#2a2a2a]">
+              <table className="w-full text-sm border-collapse">
+                <thead className="sticky top-0 bg-[#111] z-10">
+                  <tr className="border-b border-[#333]">
+                    <HeaderCell
+                      col="kind"
+                      label="Type"
+                      sortKey={sortKey}
+                      sortDir={sortDir}
+                      accent={accent}
+                      onSort={handleHeaderSort}
+                    />
+                    <HeaderCell
+                      col="title"
+                      label="Title"
+                      sortKey={sortKey}
+                      sortDir={sortDir}
+                      accent={accent}
+                      onSort={handleHeaderSort}
+                    />
+                    <HeaderCell
+                      col="date"
+                      label="Date"
+                      align="right"
+                      sortKey={sortKey}
+                      sortDir={sortDir}
+                      accent={accent}
+                      onSort={handleHeaderSort}
+                    />
+                    <th className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[#999] text-right whitespace-nowrap">
+                      Link
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((doc) => {
+                    const href =
+                      doc.source_url && /^https?:\/\//i.test(doc.source_url) ? doc.source_url : null;
+                    return (
+                      <tr
+                        key={doc.id}
+                        className="border-b border-[#222] hover:bg-[#1a1a1a] transition-colors"
+                      >
+                        <td className="px-3 py-2 text-[#aaa] whitespace-nowrap text-xs">
+                          {docCategoryLabel(doc.content_type)}
+                        </td>
+                        <td className="px-3 py-2 text-[#e5e5e5] max-w-[min(420px,50vw)]">
+                          <div className="font-medium line-clamp-2">
+                            {doc.title?.trim() || 'Untitled'}
+                          </div>
+                          {doc.snippet && (
+                            <div className="text-[#777] text-xs mt-0.5 line-clamp-2">{doc.snippet}</div>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 text-right text-[#999] tabular-nums text-xs whitespace-nowrap">
+                          {formatDate(doc.created_at)}
+                        </td>
+                        <td className="px-3 py-2 text-right whitespace-nowrap">
+                          {href ? (
+                            <a
+                              href={href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-xs hover:underline"
+                              style={{ color: accent }}
+                            >
+                              Open ↗
+                            </a>
+                          ) : (
+                            <span className="text-xs text-[#555]">
+                              {doc.content_type === 'research_report' ? 'Report' : '—'}
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui-nextjs/components/explore/RelatedDocuments.tsx
+++ b/ui-nextjs/components/explore/RelatedDocuments.tsx
@@ -237,6 +237,8 @@ export default function RelatedDocuments({
       <button
         type="button"
         onClick={toggleCollapse}
+        aria-expanded={!collapsed}
+        aria-controls="related-documents-panel"
         className="flex w-full items-center justify-between px-3 py-2 text-xs text-[#999] hover:text-white"
       >
         <span>
@@ -247,7 +249,7 @@ export default function RelatedDocuments({
       </button>
 
       {!collapsed && (
-        <div className="px-3 pb-3 space-y-3">
+        <div id="related-documents-panel" className="px-3 pb-3 space-y-3">
           <div className="flex flex-wrap gap-2">
             {chips.map((c) => (
               <button

--- a/ui-nextjs/lib/types.ts
+++ b/ui-nextjs/lib/types.ts
@@ -39,6 +39,24 @@ export interface PolicyBill {
   url: string | null;
 }
 
+/** Document row from GET /api/documents (Explore related documents). */
+export interface RelatedDocument {
+  id: string;
+  title: string | null;
+  source_url: string | null;
+  content_type: string;
+  source_key: string | null;
+  job_id: string | null;
+  created_at: string | null;
+  snippet: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface RelatedDocumentsResponse {
+  documents: RelatedDocument[];
+  total: number;
+}
+
 /** Individual task output from a CrewAI agent. */
 export interface ResearchTaskOutput {
   agent?: string;


### PR DESCRIPTION
## Summary
Adds a collapsible **Related documents** section on Explore (below state charts) for the selected state and metric, backed by a new authenticated API.

## Changes
- **GET `/api/documents`** — Query params: `state_fips` (required), optional `metric`, `types` (comma-separated: `policy_bill`, `research_report`, `scraped`, `scraped_web`), `sort`, `order`, `limit`. Returns `documents` + `total` with a first-chunk snippet and metadata.
- **`RelatedDocuments`** — Category chips (All / Policy / Research / News & web), sortable columns, external links, localStorage collapse preference.
- **Tests** — `tests/test_related_documents_params.py` for type allowlist and metric sanitization helpers.

## Dependencies
- Treats **#151** as satisfied for schema + data path: `documents` / `document_chunks` on deployed Supabase already hold policy bill rows; research/scraped types populate over time.

Closes #154

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Related documents" panel to Explore showing documents for the selected state and optional metric, with category filters, persisted collapse state, accessible sortable columns, snippets, and external links.
  * New documents API endpoint powering state/metric/type filtering, sorting, pagination, input validation, and user-scoped results.
  * Added response models/types for the new endpoint.

* **Tests**
  * Added unit tests for content-type parsing and metric normalization used by the documents flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->